### PR TITLE
Fix "unexpected keyword argument 'query'" error

### DIFF
--- a/tesla_fleet_api/energy.py
+++ b/tesla_fleet_api/energy.py
@@ -63,7 +63,7 @@ class Energy:
         return await self._request(
             Method.GET,
             f"api/1/energy_sites/{energy_site_id}/telemetry_history",
-            query={
+            params={
                 "kind": kind,
                 "start_date": start_date,
                 "end_date": end_date,
@@ -84,7 +84,7 @@ class Energy:
         return await self._request(
             Method.GET,
             f"api/1/energy_sites/{energy_site_id}/calendar_history",
-            query={
+            params={
                 "kind": kind,
                 "start_date": start_date,
                 "end_date": end_date,


### PR DESCRIPTION
When using this python package to get the energy history you may receive an error that says 
```
TypeError: TeslaFleetApi._request() got an unexpected keyword argument 'query'
``` 
That is because TeslaFleetApi._request() does not take a dictionary with the key "query" for the dictionary that represents the request query params. TeslaFleetApi._request() only takes a dictionary with the key "json" for the body and or a dictionary named "params" for the query params. I have resolved and tested this new code, hope this helps!