### PR TITLE
Use `getattr` to Fix AttributeError

### DIFF
--- a/tesla_fleet_api/tesla/vehicle/commands.py
+++ b/tesla_fleet_api/tesla/vehicle/commands.py
@@ -183,7 +183,7 @@ class Session:
         self.counter = sessionInfo.counter
         self.epoch = sessionInfo.epoch
         self.delta = int(time.time()) - sessionInfo.clock_time
-        if (not self.ready or self.publicKey != sessionInfo.publicKey):
+        if (not self.ready or getattr(self, "publicKey", "None") != sessionInfo.publicKey):
             self.publicKey = sessionInfo.publicKey
             self.sharedKey = self.parent.shared_key(sessionInfo.publicKey)
             self.hmac = hmac.new(self.sharedKey, "authenticated command".encode(), hashlib.sha256).digest()


### PR DESCRIPTION
This PR fixes an issue that prevents successfully sending signed vehicle commands. I discovered this issue when debugging the issue described [here](https://github.com/home-assistant/core/issues/139165). Eventually, I was able to get past the `Vehicle did not recognize the key...` error, but then received this. I locally modified `vehiclesigned.py` to use `getattr` instead of `self.publicKey` and was able to successfully send vehicle commands.

The current state of `main` no longer has this file, however, it still has the same logic that could result in an error.

## Problem

When sending a command that requires a private/public key-pair, checking self.publicKey results in the following error:
```
    self._sessions[resp_msg.from_destination.domain].update(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        SessionInfo.FromString(resp_msg.session_info), self.private_key
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/vscode/.local/ha-venv/lib/python3.13/site-packages/tesla_fleet_api/vehiclesigned.py", line 142, in update
    if self.publicKey != sessionInfo.publicKey:
       ^^^^^^^^^^^^^^
AttributeError: 'Session' object has no attribute 'publicKey'
```

## Solution
Use `getattr` and provide a default value instead to prevent the `AttributeError`,



