### PR TITLE
Remove unreferenced/unused type from navigation_sc_request

### DIFF
--- a/tesla_fleet_api/tesla/vehicle/fleet.py
+++ b/tesla_fleet_api/tesla/vehicle/fleet.py
@@ -216,7 +216,7 @@ class VehicleFleet(Vehicle):
         )
 
     async def navigation_sc_request(
-        self, id: int, order: int = 0 | None = None
+        self, id: int, order: int | None = None
     ) -> dict[str, Any]:
         """Send a navigation request to a Tesla supercharger (and if applicable begin preconditioning)."""
         return await self._request(

--- a/tesla_fleet_api/tesla/vehicle/fleet.py
+++ b/tesla_fleet_api/tesla/vehicle/fleet.py
@@ -216,13 +216,13 @@ class VehicleFleet(Vehicle):
         )
 
     async def navigation_sc_request(
-        self, id: int, order: int | None = None
+        self, id: int, order: int = 0 | None = None
     ) -> dict[str, Any]:
-        """Sends a location to the in-vehicle navigation system."""
+        """Send a navigation request to a Tesla supercharger (and if applicable begin preconditioning)."""
         return await self._request(
             Method.POST,
             f"api/1/vehicles/{self.vin}/command/navigation_sc_request",
-            json={"type": type, "id": id, "order": order},
+            json={"id": id, "order": order},
         )
 
     async def remote_auto_seat_climate_request(


### PR DESCRIPTION
Removing the `type` parameter was never used (it appears to have been copied from other `navigate_*` methods), so it’s been removed.

## Side Note: How to find `id`
The `id` used in navigation_sc_request, is completely undocumented by Tesla. It took a while to figure out (as none of the IDs published publicly match this). However with some sniffing I finally found it.

With [mitmproxy](https://mitmproxy.org/) installed on your device, open Tesla App and head to `Locations` > `Charging`. Then select a charger, you'll see an API request like this.

```http
POST https://akamai-apigateway-charging-ownership.tesla.com/graphql?deviceLanguage=en&deviceCountry=AU&ttpLocale=en_AU&vin=XXXXXXX&operationName=getChargingSiteInformation
Content-Type: application/json
```

Check the response body and you'll see a `fastchargeSiteId`, this will be used as `id` in the call to `navigation_sc_request`.

```json
{
  "data": {
    "charging": {
      "siteStatic": {
        ...
        "fastchargeSiteId": {
          "value": 1389   # ← use this ID
        }
        ...
      }
    }
  },
  "extensions": {
    "txId": "xxxx"
  }
}