### PR TITLE
Fix partner_login default scope for energy-only partners

### DIFF
--- a/tesla_fleet_api/tesla/fleet.py
+++ b/tesla_fleet_api/tesla/fleet.py
@@ -180,7 +180,7 @@ class TeslaFleetApi(Tesla):
         self,
         client_id: str,
         client_secret: str,
-        scopes: list[Scope] = [Scope.VEHICLE_DEVICE_DATA],
+        scopes: list[Scope] = [Scope.OPENID],
     ) -> dict[str, Any]:
         """Generate a partner token using client credentials authentication.
 


### PR DESCRIPTION
## Summary

- Change the default `scopes` parameter in `partner_login()` from `[Scope.VEHICLE_DEVICE_DATA]` to `[Scope.OPENID]`

## Problem

Partners who only have energy products (e.g. Powerwall) and no Tesla vehicles get an `invalid_scope` error when calling `partner_login()` without explicitly specifying scopes. This happens because `vehicle_device_data` is not granted to energy-only partner applications, so the token request is rejected by Tesla's auth server.

## Fix

Since `partner_login` uses the `client_credentials` OAuth flow for partner-level authentication (not user-specific access), the default scope should not assume any particular product. `openid` is a universally available scope that works regardless of which product-specific scopes are granted to the partner application.

Partners who need specific scopes can still pass them explicitly via the `scopes` parameter.