### PR TITLE
feat(energy): add island mode control for Powerwall off-grid/reconnect

### DIFF
--- a/tesla_fleet_api/const.py
+++ b/tesla_fleet_api/const.py
@@ -181,6 +181,18 @@ class TeslaEnergyPeriod(StrEnum):
     LIFETIME = "lifetime"
 
 
+class EnergyIslandMode(IntEnum):
+    """Island mode values for setIslandModeRequest.
+
+    Discovered via mitmproxy capture of the Tesla mobile app.
+    Mode 6 physically opens the grid contactor (off-grid).
+    Mode 1 physically closes it (reconnect / on-grid).
+    """
+
+    ON_GRID = 1
+    OFF_GRID = 6
+
+
 class EnergyDeviceIdentifierType(IntEnum):
     """Identifier type for energy device gRPC commands."""
 

--- a/tesla_fleet_api/tesla/energysite.py
+++ b/tesla_fleet_api/tesla/energysite.py
@@ -4,6 +4,7 @@ from tesla_fleet_api.const import (
     Method,
     EnergyOperationMode,
     EnergyExportMode,
+    EnergyIslandMode,
     TeslaEnergyPeriod,
     EnergyDeviceIdentifierType,
 )
@@ -82,6 +83,42 @@ class EnergySite:
     async def cancel_backup_event(self) -> dict[str, Any]:
         """Cancel a scheduled manual backup event on the energy gateway."""
         return await self._command("teg", "cancel_manual_backup_event_request")
+
+    async def set_island_mode(
+        self,
+        mode: EnergyIslandMode | int,
+    ) -> dict[str, Any]:
+        """Set the island mode on the energy gateway.
+
+        Physically opens or closes the grid contactor on Powerwall 2/3.
+        Requires the command to be sent as a signed RoutableMessage via
+        the ``device_command`` endpoint — unsigned ``grpc_command`` calls
+        are accepted but do not physically operate the contactor on PW3.
+
+        Args:
+            mode: EnergyIslandMode.OFF_GRID (6) to island,
+                  EnergyIslandMode.ON_GRID (1) to reconnect.
+        """
+        return await self._command(
+            "teg",
+            "set_island_mode_request",
+            {"mode": int(mode), "force": False},
+        )
+
+    async def go_off_grid(self) -> dict[str, Any]:
+        """Physically disconnect from the grid (open contactor).
+
+        Convenience wrapper around set_island_mode(OFF_GRID).
+        Causes an inverter restart (~30s solar dropout).
+        """
+        return await self.set_island_mode(EnergyIslandMode.OFF_GRID)
+
+    async def reconnect_grid(self) -> dict[str, Any]:
+        """Reconnect to the grid (close contactor).
+
+        Convenience wrapper around set_island_mode(ON_GRID).
+        """
+        return await self.set_island_mode(EnergyIslandMode.ON_GRID)
 
     async def backup(self, backup_reserve_percent: int) -> dict[str, Any]:
         """Adjust the site's backup reserve."""


### PR DESCRIPTION
## Summary

Adds island mode (off-grid/reconnect) control methods to `EnergySite`.

- `set_island_mode(mode)` — set island mode via `teg.set_island_mode_request`
- `go_off_grid()` — convenience wrapper, physically opens grid contactor
- `reconnect_grid()` — convenience wrapper, physically closes grid contactor  
- `EnergyIslandMode` enum — `ON_GRID = 1`, `OFF_GRID = 6`

## Discovery

Reverse-engineered via mitmproxy capture of the Tesla mobile app's "Go Off-Grid" button:

- The Tesla app sends `setIslandModeRequest(mode=6, force=false)` to physically island
- `mode=1` reconnects to grid
- `mode=2` (previously assumed by the community to be off-grid) is accepted by the gateway but **does not physically operate the contactor** on PW3 firmware 26.2.1

## Important: Signed Commands Required on PW3

On Powerwall 3, this command must be delivered as a **signed RoutableMessage** via the `device_command` endpoint's `routable_message` field (not `energy_device_message`). The unsigned `grpc_command` path added here is accepted by the gateway but returns `"signature required: no authorized client public key"`.

The full working flow for PW3:
1. Pair an RSA key with the gateway via `add_authorized_client_request`
2. Build a `MessageEnvelope` with `deliveryChannel=2`, `sender.authorizedClient=1`, `recipient.din=<gateway_din>`, `teg.setIslandModeRequest(mode=6)`
3. Wrap in a `RoutableMessage` with RSA-PKCS1v15-SHA512 signature over TLV-encoded payload
4. Base64-encode and send as `routable_message` in `POST /api/1/energy_sites/{id}/device_command`

On Powerwall 2, the local REST endpoint `/api/v2/islanding/mode` works without signing.

## Confirmed Working

Powerwall 3 firmware 26.2.1 — both off-grid and reconnect confirmed. First open-source implementation of PW3 islanding control.