### PR TITLE
fix(energy): island mode requires force=True for off-grid

### DIFF
--- a/tesla_fleet_api/const.py
+++ b/tesla_fleet_api/const.py
@@ -184,9 +184,15 @@ class TeslaEnergyPeriod(StrEnum):
 class EnergyIslandMode(IntEnum):
     """Island mode values for setIslandModeRequest.
 
-    Discovered via mitmproxy capture of the Tesla mobile app.
-    Mode 6 physically opens the grid contactor (off-grid).
-    Mode 1 physically closes it (reconnect / on-grid).
+    Discovered via mitmproxy capture of the Tesla mobile app and
+    confirmed on PW2 (firmware 26.10.0) and PW3 (firmware 26.2.1).
+
+    Mode 6 physically opens the grid contactor (off-grid) when sent
+    with force=True. Mode 1 physically closes it (reconnect / on-grid).
+
+    Note: mode=2 (previously assumed by the community to be off-grid)
+    sets a preference but does NOT physically operate the contactor
+    on either PW2 or PW3.
     """
 
     ON_GRID = 1

--- a/tesla_fleet_api/tesla/energysite.py
+++ b/tesla_fleet_api/tesla/energysite.py
@@ -87,29 +87,41 @@ class EnergySite:
     async def set_island_mode(
         self,
         mode: EnergyIslandMode | int,
+        force: bool | None = None,
     ) -> dict[str, Any]:
         """Set the island mode on the energy gateway.
 
         Physically opens or closes the grid contactor on Powerwall 2/3.
         Requires the command to be sent as a signed RoutableMessage via
         the ``device_command`` endpoint — unsigned ``grpc_command`` calls
-        are accepted but do not physically operate the contactor on PW3.
+        are accepted but do not physically operate the contactor.
+
+        Confirmed working on PW2 (firmware 26.10.0) and PW3 (firmware
+        26.2.1) when delivered as a signed ``routable_message`` with
+        ``force=True`` for off-grid.
 
         Args:
             mode: EnergyIslandMode.OFF_GRID (6) to island,
                   EnergyIslandMode.ON_GRID (1) to reconnect.
+            force: Whether to force the contactor operation. Defaults to
+                   True for OFF_GRID, False for ON_GRID. Required for
+                   off-grid — without force=True the gateway acknowledges
+                   the command but does not physically open the contactor.
         """
+        if force is None:
+            force = int(mode) == EnergyIslandMode.OFF_GRID
         return await self._command(
             "teg",
             "set_island_mode_request",
-            {"mode": int(mode), "force": False},
+            {"mode": int(mode), "force": force},
         )
 
     async def go_off_grid(self) -> dict[str, Any]:
         """Physically disconnect from the grid (open contactor).
 
-        Convenience wrapper around set_island_mode(OFF_GRID).
-        Causes an inverter restart (~30s solar dropout).
+        Convenience wrapper around set_island_mode(OFF_GRID, force=True).
+        Confirmed working on both Powerwall 2 and Powerwall 3 when sent
+        as a signed RoutableMessage via the device_command endpoint.
         """
         return await self.set_island_mode(EnergyIslandMode.OFF_GRID)
 


### PR DESCRIPTION
## Summary

- `set_island_mode()` now sends `force=True` when going off-grid (mode=6)
- Added optional `force` parameter for explicit control
- Updated docstrings with PW2 and PW3 confirmation

## Problem

The previous implementation (#32) sent `force=False` for all island mode commands. While the gateway accepts the command (200 OK with `CgA=` protobuf ack), it does **not** physically open the grid contactor without `force=True`. This was confirmed on Powerwall 2.

## Testing

Confirmed working on:
- **Powerwall 2** — firmware 26.10.0, signed `routable_message` via `device_command` with `force=True`
- **Powerwall 3** — firmware 26.2.1, same method

Both off-grid (`mode=6, force=True`) and reconnect (`mode=1, force=False`) confirmed.

### What doesn't work
- `mode=2` — sets a preference only, does not operate contactor on either PW2 or PW3
- `force=False` with `mode=6` — gateway acknowledges but does not island
- Local TEDAPI v1r `set_island_mode` — returns success but does not physically operate the contactor. Cloud signed `routable_message` via `device_command` is the only working path.

## Discovery

Tested systematically on a live PW2 system:
- Tried all modes 1–10 with `force=False` → none islanded
- Tried `force=True` with `mode=6` → immediate `off_grid_intentional`
- `force=True` is the critical missing piece — mode=6 alone is not enough