### PR TITLE
Add minimum version constraints to runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,13 +16,13 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-    "aiohttp",
-    "aiofiles",
-    "aiolimiter",
-    "cryptography",
-    "protobuf",
-    "bleak",
-    "bleak-retry-connector",
+    "aiohttp>=3",
+    "aiofiles>=24",
+    "aiolimiter>=1",
+    "cryptography>=43",
+    "protobuf>=6.31.1",
+    "bleak>=0.22",
+    "bleak-retry-connector>=3.9",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -929,7 +929,7 @@ wheels = [
 
 [[package]]
 name = "tesla-fleet-api"
-version = "1.4.6"
+version = "1.4.7"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -948,13 +948,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiofiles" },
-    { name = "aiohttp" },
-    { name = "aiolimiter" },
-    { name = "bleak" },
-    { name = "bleak-retry-connector" },
-    { name = "cryptography" },
-    { name = "protobuf" },
+    { name = "aiofiles", specifier = ">=24" },
+    { name = "aiohttp", specifier = ">=3" },
+    { name = "aiolimiter", specifier = ">=1" },
+    { name = "bleak", specifier = ">=0.22" },
+    { name = "bleak-retry-connector", specifier = ">=3.9" },
+    { name = "cryptography", specifier = ">=43" },
+    { name = "protobuf", specifier = ">=6.31.1" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
Declares `>=` lower-bound version floors for all seven runtime dependencies in `pyproject.toml`, mirroring the tested versions tracked in `requirements.txt` (e.g. `aiohttp>=3`, `protobuf>=6.31.1`, `bleak>=0.22`). Previously these were bare names, so PyPI consumers of a pinned release could resolve future major versions that were never tested against the library. Floors only — no upper caps were added, leaving capping as a separate maintainer decision. `uv.lock` is regenerated with the new specifiers (and a stale package self-version correction `1.4.6`→`1.4.7`); verified with `uv sync`, `uv build`, and `pyright` (0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)