### PR TITLE
fix(vehicle): standardize auto seat climate on 1-indexed AutoSeat (fixes #11)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,4 +97,5 @@ Generated protobuf files live in `tesla/vehicle/proto/` and are excluded from ru
 - **Linting**: ruff (proto files excluded).
 - **Async**: All API methods are `async`. Uses `aiohttp` for HTTP, `aiofiles` for file I/O, `bleak` for BLE.
 - **Enums**: Custom `StrEnum`/`IntEnum` in `const.py` (not stdlib). `Region` is a `Literal["na", "eu", "cn"]`, not an enum.
+- **Seat indexing gotcha**: two distinct seat enums with different conventions. `Seat` is **0-indexed** (`FRONT_LEFT=0`) and is for the manual seat heater/cooler paths (`remote_seat_heater_request`, `remote_seat_cooler_request`). `AutoSeat` is **1-indexed** (`FRONT_LEFT=1`, `FRONT_RIGHT=2`) and is the correct type for `remote_auto_seat_climate_request` on **both** backends — its values equal Tesla's REST wire values and the proto `AutoSeatPosition_*` enum. Don't mix them; passing a `Seat` to the auto-climate command is off-by-one (issue #11).
 - **Naming**: camelCase for class instance attributes that mirror API structure (`energySites`, `createFleet`). Snake_case for method names that are API endpoints.

--- a/tesla_fleet_api/tesla/vehicle/commands.py
+++ b/tesla_fleet_api/tesla/vehicle/commands.py
@@ -3,7 +3,7 @@ from abc import ABC, abstractmethod
 
 import struct
 from random import randbytes
-from typing import Any, TYPE_CHECKING, ClassVar, Generic, Literal, TypeVar
+from typing import Any, TYPE_CHECKING, ClassVar, Generic, Literal, TypeVar, cast
 import time
 import hmac
 import hashlib
@@ -27,6 +27,7 @@ from tesla_fleet_api.tesla.vehicle.vehicle import Vehicle
 
 from tesla_fleet_api.const import (
     LOGGER,
+    AutoSeat,
     Trunk,
     ClimateKeeperMode,
     CabinOverheatProtectionTemp,
@@ -191,11 +192,6 @@ if TYPE_CHECKING:
 CommandParentT = TypeVar("CommandParentT", bound="Tesla")
 
 # ENUMs to convert ints to proto typed ints
-AutoSeatClimatePositions = (
-    AutoSeatClimateAction.AutoSeatPosition_FrontLeft,
-    AutoSeatClimateAction.AutoSeatPosition_FrontRight,
-)
-
 HvacSeatCoolerLevels = (
     HvacSeatCoolerActions.HvacSeatCoolerLevel_Off,
     HvacSeatCoolerActions.HvacSeatCoolerLevel_Low,
@@ -994,11 +990,18 @@ class Commands(ABC, Vehicle[CommandParentT], Generic[CommandParentT]):
         )
 
     async def remote_auto_seat_climate_request(
-        self, auto_seat_position: int, auto_climate_on: bool
+        self, auto_seat_position: int | AutoSeat, auto_climate_on: bool
     ) -> dict[str, Any]:
-        """Sets automatic seat heating and cooling."""
+        """Sets automatic seat heating and cooling.
+
+        ``auto_seat_position`` is 1-indexed (``AutoSeat.FRONT_LEFT`` == 1),
+        matching Tesla's wire values and the proto ``AutoSeatPosition_*`` enum.
+        """
         # AutoSeatPosition_FrontLeft = 1;
         # AutoSeatPosition_FrontRight = 2;
+        # AutoSeat's 1-indexed values equal the proto AutoSeatPosition_* values,
+        # so the int maps directly onto the proto enum (protobuf accepts the
+        # raw int for enum fields).
         return await self._sendInfotainment(
             Action(
                 vehicleAction=VehicleAction(
@@ -1006,9 +1009,10 @@ class Commands(ABC, Vehicle[CommandParentT], Generic[CommandParentT]):
                         carseat=[
                             AutoSeatClimateAction.CarSeat(
                                 on=auto_climate_on,
-                                seat_position=AutoSeatClimatePositions[
-                                    auto_seat_position
-                                ],
+                                seat_position=cast(
+                                    "AutoSeatClimateAction.AutoSeatPosition_E",
+                                    auto_seat_position,
+                                ),
                             )
                         ]
                     )

--- a/tesla_fleet_api/tesla/vehicle/fleet.py
+++ b/tesla_fleet_api/tesla/vehicle/fleet.py
@@ -5,6 +5,7 @@ from time import time
 from typing import TYPE_CHECKING, Any, Generic, List, TypeVar
 
 from tesla_fleet_api.const import (
+    AutoSeat,
     CabinOverheatProtectionTemp,
     ClimateKeeperMode,
     Level,
@@ -235,10 +236,14 @@ class VehicleFleet(Vehicle[FleetParentT], Generic[FleetParentT]):
 
     async def remote_auto_seat_climate_request(
         self,
-        auto_seat_position: int | Seat,
+        auto_seat_position: int | AutoSeat,
         auto_climate_on: bool,
     ) -> dict[str, Any]:
-        """Sets automatic seat heating and cooling."""
+        """Sets automatic seat heating and cooling.
+
+        ``auto_seat_position`` is 1-indexed (``AutoSeat.FRONT_LEFT`` == 1),
+        matching Tesla's wire values for this endpoint.
+        """
         return await self._request(
             Method.POST,
             f"api/1/vehicles/{self.vin}/command/remote_auto_seat_climate_request",

--- a/tests/test_auto_seat_climate.py
+++ b/tests/test_auto_seat_climate.py
@@ -1,0 +1,105 @@
+"""Regression tests for issue #11 — auto seat climate seat indexing.
+
+The auto-seat-climate command is 1-indexed (``AutoSeat.FRONT_LEFT`` == 1),
+matching Tesla's wire values and the proto ``AutoSeatPosition_*`` enum. Both the
+Fleet REST path and the signed/protobuf path must agree on that convention for
+the same input.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from tesla_fleet_api.const import AutoSeat, Method
+from tesla_fleet_api.tesla.vehicle.commands import Commands
+from tesla_fleet_api.tesla.vehicle.fleet import VehicleFleet
+from tesla_fleet_api.tesla.vehicle.proto.car_server_pb2 import (
+    Action,
+    AutoSeatClimateAction,
+)
+
+VIN = "5YJXCAE43LF123456"
+
+
+class _TestCommands(Commands):
+    """Concrete ``Commands`` subclass so the ABC can be instantiated in tests."""
+
+    _auth_method = "hmac"
+
+    async def _send(self, msg, requires):  # pragma: no cover - never invoked
+        raise NotImplementedError
+
+
+class AutoSeatClimateFleetTests(IsolatedAsyncioTestCase):
+    """The Fleet REST path sends the 1-indexed seat position verbatim."""
+
+    def create_vehicle(self) -> tuple[VehicleFleet, AsyncMock]:
+        parent = MagicMock()
+        request = AsyncMock(return_value={"response": {"result": True}})
+        parent._request = request  # pyright: ignore[reportAttributeAccessIssue]
+        return VehicleFleet(parent, VIN), request
+
+    async def test_front_left_sends_index_one(self) -> None:
+        vehicle, request = self.create_vehicle()
+
+        await vehicle.remote_auto_seat_climate_request(AutoSeat.FRONT_LEFT, True)
+
+        request.assert_awaited_once_with(
+            Method.POST,
+            f"api/1/vehicles/{VIN}/command/remote_auto_seat_climate_request",
+            json={"auto_seat_position": 1, "auto_climate_on": True},
+        )
+
+    async def test_front_right_sends_index_two(self) -> None:
+        vehicle, request = self.create_vehicle()
+
+        await vehicle.remote_auto_seat_climate_request(AutoSeat.FRONT_RIGHT, False)
+
+        request.assert_awaited_once_with(
+            Method.POST,
+            f"api/1/vehicles/{VIN}/command/remote_auto_seat_climate_request",
+            json={"auto_seat_position": 2, "auto_climate_on": False},
+        )
+
+
+class AutoSeatClimateSignedTests(IsolatedAsyncioTestCase):
+    """The signed/protobuf path maps the same 1-indexed input onto the proto enum."""
+
+    def create_vehicle(self) -> tuple[_TestCommands, AsyncMock]:
+        parent = MagicMock()
+        parent.private_key = ec.generate_private_key(ec.SECP256R1())
+        vehicle = _TestCommands(parent, VIN)
+        send = AsyncMock(return_value={"response": {"result": True}})
+        vehicle._sendInfotainment = send  # pyright: ignore[reportAttributeAccessIssue]
+        return vehicle, send
+
+    def _seat_position(self, send: AsyncMock) -> int:
+        action: Action = send.await_args.args[0]
+        carseats = action.vehicleAction.autoSeatClimateAction.carseat
+        self.assertEqual(len(carseats), 1)
+        return carseats[0].seat_position
+
+    async def test_front_left_emits_front_left_proto(self) -> None:
+        vehicle, send = self.create_vehicle()
+
+        await vehicle.remote_auto_seat_climate_request(AutoSeat.FRONT_LEFT, True)
+
+        self.assertEqual(
+            self._seat_position(send),
+            AutoSeatClimateAction.AutoSeatPosition_FrontLeft,
+        )
+        self.assertTrue(
+            send.await_args.args[0].vehicleAction.autoSeatClimateAction.carseat[0].on
+        )
+
+    async def test_front_right_emits_front_right_proto(self) -> None:
+        vehicle, send = self.create_vehicle()
+
+        # AutoSeat.FRONT_RIGHT == 2 must no longer raise (previously IndexError).
+        await vehicle.remote_auto_seat_climate_request(AutoSeat.FRONT_RIGHT, False)
+
+        self.assertEqual(
+            self._seat_position(send),
+            AutoSeatClimateAction.AutoSeatPosition_FrontRight,
+        )


### PR DESCRIPTION
## Intent

Fix issue #11: the auto-seat-climate command (remote_auto_seat_climate_request) is 1-indexed on Tesla's wire (AutoSeatPosition_FrontLeft=1, FrontRight=2), but the library's two backends disagreed with each other and with the 0-indexed Seat enum, so Seat.FRONT_LEFT=0 was rejected and Seat.FRONT_RIGHT=1 controlled the front-left seat. DECISION (made by the maintainer, do not re-litigate): standardize BOTH backends on the 1-indexed AutoSeat enum (FL=1, FR=2), which already matches the REST wire values and the proto AutoSeatPosition_* enum. Changes: (1) fleet.py REST path — change type hint 'int | Seat' to 'int | AutoSeat' and import AutoSeat; this is a correctness/clarity change with NO behavior change since the REST path already forwarded the value verbatim to the 1-indexed endpoint. (2) commands.py signed/protobuf path — map the 1-indexed int directly onto the proto enum (via typing.cast for pyright strict; protobuf accepts the raw int at runtime) INSTEAD of indexing the removed 0-based AutoSeatClimatePositions tuple, so AutoSeat.FRONT_RIGHT=2 no longer raises IndexError; type hint updated to 'int | AutoSeat'. This is a DELIBERATE behavior change on the signed path: its expected index moves 0->1, so a direct caller of the signed method must now pass 1-indexed values — this is intended and called out in the commit body. (3) AutoSeat already sits alongside Seat in const.py so it is importable from the same module. (4) Added regression tests (tests/test_auto_seat_climate.py) asserting the Fleet JSON body carries auto_seat_position=1/2 and the signed builder emits AutoSeatPosition_FrontLeft/FrontRight for the same 1-indexed input. The manual seat-heater/cooler paths and the 0-indexed Seat enum are intentionally left unchanged (they are correct). Also recorded the dual seat-indexing gotcha in AGENTS.md. Out of scope but noted for the maintainer: the Home Assistant tesla_fleet integration must also pass 1-indexed AutoSeat values to fully close the end-user symptom; HA is not touched here.

## What Changed

- `remote_auto_seat_climate_request` now standardizes both backends on the 1-indexed `AutoSeat` enum (FRONT_LEFT=1, FRONT_RIGHT=2), matching Tesla's REST wire values and the proto `AutoSeatPosition_*` enum; the REST path in `fleet.py` gains the `int | AutoSeat` type hint and `AutoSeat` import (value already forwarded verbatim, no behavior change).
- The signed/protobuf path in `commands.py` now casts the 1-indexed int directly onto the proto enum instead of indexing the removed 0-based `AutoSeatClimatePositions` tuple, so `AutoSeat.FRONT_RIGHT=2` no longer raises `IndexError` — a deliberate index shift (0→1) for direct callers of the signed method.
- Added regression tests (`tests/test_auto_seat_climate.py`) asserting the Fleet JSON carries `auto_seat_position=1/2` and the signed builder emits `AutoSeatPosition_FrontLeft/FrontRight` for the same input, and documented the dual seat-indexing gotcha in `AGENTS.md`.

## Risk Assessment

✅ Low: A tightly-bounded correctness fix that standardizes both backends on the 1-indexed AutoSeat convention matching the proto enum and REST wire values, with matching regression tests and no other affected call sites.

## Testing

Baseline `uv sync` plus `uv run pytest tests` (41 passed, 8 subtests) confirm no regressions from the signature/import changes; the new `tests/test_auto_seat_climate.py` (4 tests) passes and asserts both backends agree on 1-indexed values. Since this is a library (no UI surface), the end-user-experience evidence is a runnable demo capturing the real command payloads: the Fleet REST path forwards auto_seat_position 1/2 verbatim and the signed path maps them onto AutoSeatPosition_FrontLeft/FrontRight, while a reproduction of the removed 0-indexed tuple lookup shows the old bug (IndexError for FRONT_RIGHT=2, and FRONT_LEFT=1 wrongly emitting FrontRight) that the fix eliminates. No visual artifact applies because there is no rendered UI. Transient egg-info change from the editable install was reverted; worktree is clean.

<details>
<summary>Evidence: Auto-seat-climate end-to-end demo (payloads + old-vs-new behavior)</summary>

<code>### Caller: remote_auto_seat_climate_request(1, True)&#10;[Fleet REST] POST body -&gt; {&#39;auto_seat_position&#39;: &lt;AutoSeat.FRONT_LEFT: 1&gt;, &#39;auto_climate_on&#39;: True}&#10;[Signed/proto] seat_position -&gt; 1 (AutoSeatPosition_FrontLeft)&#10;### Caller: remote_auto_seat_climate_request(2, True)&#10;[Fleet REST] POST body -&gt; {&#39;auto_seat_position&#39;: &lt;AutoSeat.FRONT_RIGHT: 2&gt;, &#39;auto_climate_on&#39;: True}&#10;[Signed/proto] seat_position -&gt; 2 (AutoSeatPosition_FrontRight)&#10;### Regression: OLD signed-path bug&#10;OLD with AutoSeat.FRONT_RIGHT(=2): IndexError: tuple index out of range&#10;OLD with AutoSeat.FRONT_LEFT(=1): emitted AutoSeatPosition_FrontRight (wrong seat!)&#10;FIX confirmed: new code emits the correct seat for both, no IndexError.</code>

```text
"""End-to-end demo of the issue #11 fix: auto-seat-climate uses 1-indexed AutoSeat
consistently on BOTH the Fleet REST backend and the signed/protobuf backend.

Shows the actual command payloads an end user's call produces, and reproduces the
OLD broken signed-path behavior for contrast.
"""
import asyncio
from unittest.mock import AsyncMock, MagicMock
from cryptography.hazmat.primitives.asymmetric import ec

from tesla_fleet_api.const import AutoSeat
from tesla_fleet_api.tesla.vehicle.fleet import VehicleFleet
from tesla_fleet_api.tesla.vehicle.commands import Commands
from tesla_fleet_api.tesla.vehicle.proto.car_server_pb2 import Action, AutoSeatClimateAction

VIN = "5YJXCAE43LF123456"
PROTO_NAME = {1: "AutoSeatPosition_FrontLeft", 2: "AutoSeatPosition_FrontRight"}


class _C(Commands):
    _auth_method = "hmac"
    async def _send(self, msg, requires):
        raise NotImplementedError


def fleet():
    parent = MagicMock()
    parent._request = AsyncMock(return_value={"response": {"result": True}})
    return VehicleFleet(parent, VIN), parent._request


def signed():
    parent = MagicMock()
    parent.private_key = ec.generate_private_key(ec.SECP256R1())
    v = _C(parent, VIN)
    v._sendInfotainment = AsyncMock(return_value={"response": {"result": True}})
    return v, v._sendInfotainment


async def main():
    print("=" * 68)
    print("AutoSeat enum (1-indexed, matches Tesla wire + proto):")
    print(f"  AutoSeat.FRONT_LEFT  = {int(AutoSeat.FRONT_LEFT)}")
    print(f"  AutoSeat.FRONT_RIGHT = {int(AutoSeat.FRONT_RIGHT)}")
    print("=" * 68)

    for seat in (AutoSeat.FRONT_LEFT, AutoSeat.FRONT_RIGHT):
        print(f"\n### Caller: remote_auto_seat_climate_request({seat!s}, True)")

        v, req = fleet()
        await v.remote_auto_seat_climate_request(seat, True)
        body = req.await_args.kwargs["json"]
        print(f"  [Fleet REST]  POST body -> {body}")
        assert body["auto_seat_position"] == int(seat)

        v, send = signed()
        await v.remote_auto_seat_climate_request(seat, True)
        action: Action = send.await_args.args[0]
        pos = action.vehicleAction.autoSeatClimateAction.carseat[0].seat_position
        print(f"  [Signed/proto] seat_position -> {pos} ({PROTO_NAME[pos]})")
        assert pos == int(seat)
        assert AutoSeatClimateAction.AutoSeatPosition_E.Name(pos) == PROTO_NAME[pos]

    print("\n" + "=" * 68)
    print("Both backends agree: FRONT_LEFT->1->FrontLeft, FRONT_RIGHT->2->FrontRight")
    print("=" * 68)

    print("\n### Regression: reproduce the OLD signed-path bug (pre-fix)")
    print("Old code did: AutoSeatClimatePositions[auto_seat_position]  (0-indexed tuple)")
    OLD = (
        AutoSeatClimateAction.AutoSeatPosition_FrontLeft,   # index 0
        AutoSeatClimateAction.AutoSeatPosition_FrontRight,  # index 1
    )
    try:
        _ = OLD[int(AutoSeat.FRONT_RIGHT)]  # index 2 -> boom
        print("  UNEXPECTED: no error")
    except IndexError as e:
        print(f"  OLD behavior with AutoSeat.FRONT_RIGHT(=2): IndexError: {e}")
    old_fl = OLD[int(AutoSeat.FRONT_LEFT)]  # index 1 -> WRONG seat (FrontRight)
    print(f"  OLD behavior with AutoSeat.FRONT_LEFT(=1): emitted "
          f"{AutoSeatClimateAction.AutoSeatPosition_E.Name(old_fl)} (wrong seat!)")
    print("\nFIX confirmed: new code emits the correct seat for both, no IndexError.")


asyncio.run(main())
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Review** - 1 info</summary>

- ℹ️ `tesla_fleet_api/tesla/vehicle/commands.py:1012` - The signed path previously validated the seat index implicitly: AutoSeatClimatePositions[auto_seat_position] raised IndexError for out-of-range values. The new `cast(...)` forwards any int verbatim to the proto enum, so an out-of-range value (e.g. old 0-indexed callers passing 0) now silently serializes as AutoSeatPosition_Unknown (proto value 0) instead of failing fast. This matches the REST path (which also never validated) and is consistent with the deliberate 1-indexed standardization, so it&#39;s an acceptable tradeoff — noted only for awareness.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest tests/test_auto_seat_climate.py -v` — 4 regression tests (Fleet JSON carries auto_seat_position=1/2; signed builder emits AutoSeatPosition_FrontLeft/FrontRight for same 1-indexed input)</code>
- <code>`uv run pytest tests -q` — full suite, 41 passed + 8 subtests</code>
- <code>`uv run python demo_auto_seat_climate.py` — end-to-end demo printing the Fleet REST POST body and signed proto seat_position for FRONT_LEFT/FRONT_RIGHT, plus reproduction of the old 0-indexed-tuple bug (IndexError at index 2, wrong-seat at index 1)</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
