### PR TITLE
fix(ci): auto-generate GitHub release notes on publish

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -72,7 +72,7 @@ jobs:
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
-          --notes ""
+          --generate-notes
       - name: Upload artifacts to GitHub Release
         env:
           GITHUB_TOKEN: ${{ github.token }}


### PR DESCRIPTION
## Intent

The developer wanted the PyPI publish GitHub Actions workflow for the python-tesla-fleet-api repo to auto-generate GitHub release notes instead of creating releases with an empty body, which had required manual editing after releases like v1.5.2. The specific requirement was a minimal change to the github-release job in .github/workflows/python-publish.yml, replacing the `gh release create --notes ""` flag with `--generate-notes`, while leaving the rest of the job (dist upload, signing, permissions) untouched. Constraints included verifying the flag against gh's help, ensuring the workflow YAML remained valid, limiting the diff to only that one flag change, committing on a dedicated branch (fm/tfa-release-notes-w9) without pushing to the default branch, and validating/shipping the change through the no-mistakes pipeline to a PR with green CI. After the pipeline's push step initially failed due to a GitHub token lacking workflow scope, the developer refreshed the token and asked to retry the pipeline and report done with the PR URL once checks were green.

## What Changed

- Replaced the empty `--notes ""` flag with `--generate-notes` on the `gh release create` step in the `github-release` job of `.github/workflows/python-publish.yml`, so PyPI publish releases are stamped with auto-generated "What's Changed" notes instead of an empty body that required manual editing (as happened for v1.5.2).
- The rest of the job (dist upload, artifact signing, permissions) is unchanged; the diff is limited to that single flag.

## Risk Assessment

✅ Low: Single-line CI workflow change swapping a verified-valid gh flag (--notes "" → --generate-notes) with required permissions already in place and no impact on the publish, signing, or upload steps.

## Testing

Exercised the CI workflow change end-to-end without publishing anything: confirmed the diff is only the intended flag swap, validated the workflow YAML, verified --generate-notes against gh's help, executed the rendered release step against a stub gh to capture the exact command a tag push will run, and captured before/after product evidence — the production v1.5.2 run log showing the old empty-notes command versus a GitHub generate-notes API preview showing the auto-generated "What's Changed" body. No Python code changed, so the unit suite was not relevant; all checks passed.

<details>
<summary>Evidence: Simulated release step (rendered command + stub-gh argv)</summary>

<code>Rendered step command: gh release create &#39;v1.5.2&#39; --repo &#39;Teslemetry/python-tesla-fleet-api&#39; --generate-notes&#10;stub-gh invoked as:&#10;argv[1]=release&#10;argv[2]=create&#10;argv[3]=v1.5.2&#10;argv[4]=--repo&#10;argv[5]=Teslemetry/python-tesla-fleet-api&#10;argv[6]=--generate-notes</code>

```text
Rendered step command: gh release create 'v1.5.2' --repo 'Teslemetry/python-tesla-fleet-api' --generate-notes
stub-gh invoked as:
  argv[0]=gh
  argv[1]=release
  argv[2]=create
  argv[3]=v1.5.2
  argv[4]=--repo
  argv[5]=Teslemetry/python-tesla-fleet-api
  argv[6]=--generate-notes
```
</details>
<details>
<summary>Evidence: Before/after: old workflow&#39;s empty-notes command in production log vs generate-notes API preview</summary>

<code>BEFORE (run 28638078573, tag v1.5.2): Run gh release create &#39;v1.5.2&#39; --repo &#39;Teslemetry/python-tesla-fleet-api&#39; --notes &#34;&#34;&#10;AFTER (generate-notes API preview, v1.5.1..v1.5.2 range):&#10;## What&#39;s Changed&#10;* fix(proto): pin protobuf gencode to 6.32.0... (#40)&#10;* fix(vehicle): standardize auto seat climate on 1-indexed AutoSeat (#41)&#10;* feat(vehicle): add low power mode and keep accessory power signed commands (#42)&#10;**Full Changelog**: .../compare/v1.5.1...v1.5.2-notes-preview</code>

```text
BEFORE — production run of the OLD workflow (run 28638078573, tag v1.5.2, 2026-07-03T04:18Z):
The Actions log shows the release was created with an empty body:

  Create GitHub Release | ##[group]Run gh release create 'v1.5.2' --repo 'Teslemetry/python-tesla-fleet-api' --notes ""

(The v1.5.2 release now shows a "What's Changed" body only because the author
manually edited it after publishing — the exact toil this change removes.)

AFTER — what --generate-notes will produce. Preview from GitHub's own
generate-notes API (the same API the gh flag calls; read-only computation,
no release created), for the v1.5.1..v1.5.2 range:

## What's Changed
* fix(proto): pin protobuf gencode to 6.32.0 for Home Assistant compatibility by @Bre77 in https://github.com/Teslemetry/python-tesla-fleet-api/pull/40
* fix(vehicle): standardize auto seat climate on 1-indexed AutoSeat (fixes #11) by @Bre77 in https://github.com/Teslemetry/python-tesla-fleet-api/pull/41
* feat(vehicle): add low power mode and keep accessory power signed commands by @Bre77 in https://github.com/Teslemetry/python-tesla-fleet-api/pull/42

**Full Changelog**: https://github.com/Teslemetry/python-tesla-fleet-api/compare/v1.5.1...v1.5.2-notes-preview
```
</details>
<details>
<summary>Evidence: Diff, YAML validation, and gh flag verification</summary>

```text
Diff (base 3b3ed0b..target 6bded01) — the only change in the branch:

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -72,7 +72,7 @@ jobs:
           gh release create
           '${{ github.ref_name }}'
           --repo '${{ github.repository }}'
-          --notes ""
+          --generate-notes

YAML validity: yaml.safe_load parses the workflow; the github-release
"Create GitHub Release" step's folded scalar renders to:
  gh release create '${{ github.ref_name }}' --repo '${{ github.repository }}' --generate-notes

Flag verified against gh release create --help:
      --generate-notes               Automatically generate title and notes for the release via GitHub Release Notes API
  $ gh release create v1.2.3 --generate-notes
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`git diff 3b3ed0b..6bded01` — confirmed the diff is exactly the one-flag change in .github/workflows/python-publish.yml</code>
- <code>`yaml.safe_load(&#39;.github/workflows/python-publish.yml&#39;)` — workflow YAML parses; extracted the rendered release-step command</code>
- <code>`gh release create --help | grep generate-notes` — confirmed the flag exists and is documented</code>
- <code>Executed the rendered step `gh release create &#39;v1.5.2&#39; --repo &#39;Teslemetry/python-tesla-fleet-api&#39; --generate-notes` against a stub `gh` capturing exact argv</code>
- <code>`gh run view 28638078573 --log` — production log of the v1.5.2 tag run shows the OLD command `--notes &#34;&#34;` (release created empty, then manually edited), establishing the before state</code>
- <code>`gh api repos/Teslemetry/python-tesla-fleet-api/releases/generate-notes` (read-only preview) — produced the full &#34;What&#39;s Changed&#34; body with PR links that --generate-notes will stamp on future releases</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>⚠️ **Lint** - 1 info</summary>

- ℹ️ `tesla_fleet_api/tesla/tesla.py` - Pre-existing ruff format drift in 7 Python files (e.g. tesla_fleet_api/tesla/tesla.py, tesla_fleet_api/tessie/vehicles.py) untouched by this change; left as-is to keep the diff limited to the workflow flag change.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
