### PR TITLE
fix(ble): drop scan-time service UUID filter from find_vehicle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,11 @@ Generated protobuf files live in `tesla/vehicle/proto/` and are excluded from ru
 - **Enums**: Custom `StrEnum`/`IntEnum` in `const.py` (not stdlib). `Region` is a `Literal["na", "eu", "cn"]`, not an enum.
 - **Seat indexing gotcha**: two distinct seat enums with different conventions. `Seat` is **0-indexed** (`FRONT_LEFT=0`) and is for the manual seat heater/cooler paths (`remote_seat_heater_request`, `remote_seat_cooler_request`). `AutoSeat` is **1-indexed** (`FRONT_LEFT=1`, `FRONT_RIGHT=2`) and is the correct type for `remote_auto_seat_climate_request` on **both** backends — its values equal Tesla's REST wire values and the proto `AutoSeatPosition_*` enum. Don't mix them; passing a `Seat` to the auto-climate command is off-by-one (issue #11).
 - **Naming**: camelCase for class instance attributes that mirror API structure (`energySites`, `createFleet`). Snake_case for method names that are API endpoints.
+- **BLE discovery gotcha**: a Tesla vehicle advertises no 128-bit service UUID pre-connect — only its VIN-derived local name (`^S[a-f0-9]{16}[CDRP]$`), and only in the scan response, not the `ADV_IND`. `SERVICE_UUID` (`tesla_fleet_api/tesla/vehicle/bluetooth.py`) exists only as a GATT service after connecting. Never pass `service_uuids=[SERVICE_UUID]` as a `BleakScanner` discovery-time filter — it hides the vehicle on a direct BlueZ adapter (an ESPHome proxy doesn't enforce that filter the same way, which can mask the bug in testing). Scan unfiltered with active scanning and match by name; keep `SERVICE_UUID` for post-connect GATT use only.
+
+## Maintaining this file
+
+Keep this file for knowledge useful to almost every future agent session in this project.
+Do not repeat what the codebase already shows; point to the authoritative file or command instead.
+Prefer rewriting or pruning existing entries over appending new ones.
+When updating this file, preserve this bar for all agents and keep entries concise.

--- a/tesla_fleet_api/tesla/vehicle/bluetooth.py
+++ b/tesla_fleet_api/tesla/vehicle/bluetooth.py
@@ -208,7 +208,10 @@ class VehicleBluetooth(Commands[BluetoothParentT], Generic[BluetoothParentT]):
         """Find the Tesla BLE device."""
 
         if scanner is None:
-            scanner = BleakScanner(service_uuids=[SERVICE_UUID])
+            # No service_uuids filter: the vehicle advertises no service UUID
+            # (SERVICE_UUID is GATT-only, post-connect); active scan is needed
+            # since the name lives in the scan response, not the advertisement.
+            scanner = BleakScanner(scanning_mode="active")
 
         if address is not None:
             device = await scanner.find_device_by_address(address)

--- a/tests/test_find_vehicle_scan_filter.py
+++ b/tests/test_find_vehicle_scan_filter.py
@@ -1,0 +1,61 @@
+"""Regression test: find_vehicle must not scan-filter by service UUID.
+
+The vehicle advertises no 128-bit service UUID (SERVICE_UUID is GATT-only,
+available only after connecting); it only advertises its VIN-derived name in
+the scan response. A service_uuids scan filter hides the vehicle entirely on
+a direct BlueZ adapter.
+"""
+
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from cryptography.hazmat.primitives.asymmetric import ec
+
+from tesla_fleet_api.tesla.vehicle.bluetooth import VehicleBluetooth
+
+
+class _ConcreteVehicleBluetooth(VehicleBluetooth):
+    async def _send(self, msg, requires):  # pragma: no cover - not reached
+        raise AssertionError("_send should not be called in this test")
+
+
+class FindVehicleScanFilterTests(IsolatedAsyncioTestCase):
+    VIN = "5YJXCAE43LF123456"
+
+    def _make_vehicle(self) -> _ConcreteVehicleBluetooth:
+        parent = MagicMock()
+        key = ec.generate_private_key(ec.SECP256R1())
+        return _ConcreteVehicleBluetooth(parent, self.VIN, key)
+
+    async def test_default_scanner_has_no_service_uuid_filter(self):
+        vehicle = self._make_vehicle()
+
+        fake_device = MagicMock()
+        captured_kwargs = {}
+
+        class FakeScanner:
+            def __init__(self, *args, **kwargs):
+                captured_kwargs.update(kwargs)
+
+            async def find_device_by_name(self, name):
+                return fake_device
+
+        with patch("tesla_fleet_api.tesla.vehicle.bluetooth.BleakScanner", FakeScanner):
+            device = await vehicle.find_vehicle()
+
+        self.assertIs(device, fake_device)
+        self.assertNotIn("service_uuids", captured_kwargs)
+        self.assertEqual(captured_kwargs.get("scanning_mode"), "active")
+
+    async def test_matches_by_vin_derived_name_without_service_uuid(self):
+        vehicle = self._make_vehicle()
+
+        fake_device = MagicMock()
+        find_device_by_name = AsyncMock(return_value=fake_device)
+        scanner = MagicMock()
+        scanner.find_device_by_name = find_device_by_name
+
+        device = await vehicle.find_vehicle(scanner=scanner)
+
+        find_device_by_name.assert_awaited_once_with(vehicle.ble_name)
+        self.assertIs(device, fake_device)


### PR DESCRIPTION
## Intent

- **Bug: `find_vehicle` scan-time filter hides the vehicle on a direct BlueZ adapter**
  - The vehicle advertises no 128-bit service UUID in either its `ADV_IND` or its scan response - only its VIN-derived local name (`^S[a-f0-9]{16}[CDRP]$`) is advertised, and only in the SCAN_RSP. `SERVICE_UUID` only exists as a GATT service *after* connecting.
  - `find_vehicle` scanned with `BleakScanner(service_uuids=[SERVICE_UUID])`, a discovery-time filter. Since the car never advertises that UUID, a direct `bleak`/BlueZ adapter returns zero devices and the vehicle is never found.
  - This was masked in prior testing because discovery went through an ESPHome bluetooth proxy (bleak-esphome/habluetooth), whose scanner doesn't enforce the service-UUID filter the same way - the car was still found there, papering over the bug for anyone on a direct local adapter.
- **Fix**
  - Drop the `service_uuids` filter; scan unfiltered and match by the existing VIN-derived name lookup (`find_device_by_name`), which is the actual discriminator the car exposes pre-connect.
  - Explicitly request active scanning (`scanning_mode="active"`) so the scan response - which carries the name - is captured. This matches bleak's own default, but makes the requirement explicit rather than incidental.
  - `SERVICE_UUID` itself and its post-connect GATT uses (`establish_connection(..., services=[SERVICE_UUID])`) are untouched - it's still correct there, only the scan-time filter use was wrong.
  - Scope: this is a single, minimal fix to the discovery filter. No other BLE behavior changed.

## What Changed

- `tesla_fleet_api/tesla/vehicle/bluetooth.py`: `find_vehicle`'s default `BleakScanner` no longer passes `service_uuids=[SERVICE_UUID]`; it now passes `scanning_mode="active"` instead.
- `tests/test_find_vehicle_scan_filter.py` (new): asserts the default scanner is constructed without a `service_uuids` filter and with active scanning, and that name-based matching still works end to end.

## Risk Assessment

Low, and safe by construction: removing a discovery filter can only surface *more* devices to the name-match step, never hide the target vehicle. Post-connect GATT behavior (`SERVICE_UUID` usage in `connect()`) is unchanged.

## Testing

- `uv run pytest tests` - 58 passed, 8 subtests passed.
- `uv run ruff check` / `uv run ruff format --check` on touched files - clean.
- `uv run pyright tesla_fleet_api` - 0 errors.
- Added a focused unit test verifying the scanner is built without the service-UUID filter and that name-based discovery is preserved.
- Not verified against a live direct-BlueZ adapter in this environment; the bug was originally surfaced via live BLE discovery through an ESPHome proxy, which showed the vehicle advertises only the VIN-derived name (in the scan response) and no service UUID pre-connect - the proxy's scanner just doesn't enforce the filter the way a direct BlueZ adapter does, which is why this went unnoticed until now.

<details><summary>Full narrative / original brief</summary>

`find_vehicle` scans with `BleakScanner(service_uuids=[SERVICE_UUID])` (the Tesla vehicle BLE service UUID) as a discovery-time filter. But a Tesla vehicle does not advertise that 128-bit service UUID in its advertisement or scan-response - it advertises only its VIN-derived local name (`^S[a-f0-9]{16}[CDRP]$`) in the scan response, plus a nameless iBeacon ADV_IND. The service UUID only exists as a GATT service after you connect. So filtering the scan by that UUID means a direct BlueZ/bleak adapter returns zero devices and `find_vehicle` never sees the car.

This was masked in testing because discovery went through an ESPHome bluetooth proxy (bleak-esphome/habluetooth), whose scanner does not enforce the service-UUID filter the same way - so the car was still found. On a direct local adapter it would not be.

Fix: drop the scan-time `service_uuids` filter, scan unfiltered, match by the existing VIN-derived local name, and require active scanning so the scan response (which carries the name) is captured. Keep all post-connect `SERVICE_UUID` GATT usage intact.

</details>
