### PR TITLE
fix(ble): wrap transport failures in library errors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,7 +99,7 @@ No release-please or version-bump automation. To ship: bump `version` in `pyproj
 
 `exceptions.py` maps HTTP status codes and error keys to specific exception classes. `raise_for_status()` parses responses and raises the appropriate exception. Signed command faults have separate hierarchies: `TeslaFleetInformationFault`, `TeslaFleetMessageFault`, `SignedMessageInformationFault`, `WhitelistOperationStatus`.
 
-All exceptions inherit from `TeslaFleetError(BaseException)`, deliberately **not** `Exception` — a bare `except Exception` (e.g. in retry/backoff loops around BLE reads) silently fails to catch `BluetoothTimeout` and every other library error. Catch `TeslaFleetError` (or `BaseException`) explicitly.
+All exceptions inherit from `TeslaFleetError(BaseException)`, deliberately **not** `Exception` — a bare `except Exception` (e.g. in retry/backoff loops around BLE reads) silently fails to catch `BluetoothTimeout` and every other library error. Catch `TeslaFleetError` (or `BaseException`) explicitly. `VehicleBluetooth` wraps transport-layer failures (`connect`/`connect_if_needed`, the GATT write in `_send`) in `BluetoothTransportError`, a `TeslaFleetError` subclass chaining the original `bleak.exc.BleakError` as its cause — so `except TeslaFleetError` alone now catches BLE transport failures too, not just the response-wait `BluetoothTimeout`.
 
 ### Protobuf
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ asyncio.run(main())
 
 For more detailed examples, see [Bluetooth for Vehicles](docs/bluetooth_vehicles.md).
 
+BLE connect and GATT write failures from `VehicleBluetooth` raise
+`BluetoothTransportError`, a `TeslaFleetError` subclass, with the original
+`bleak.exc.BleakError` chained as `__cause__`. Catch `TeslaFleetError` to
+handle Bluetooth transport failures and `BluetoothTimeout` response-wait
+timeouts through the same library error hierarchy.
+
 ### Routing and Failover
 
 The `Router` class composes an ordered list of two-or-more backends that share a common method surface and dispatches each method call down the chain, automatically failing over on error. `VehicleRouter` and `EnergySiteRouter` are thin entity-specific subclasses. A common setup is a local `VehicleBluetooth` primary with a cloud fallback (e.g. a `TeslemetryVehicle`), so commands go over Bluetooth when the vehicle is reachable and route to the cloud otherwise:

--- a/docs/bluetooth_vehicles.md
+++ b/docs/bluetooth_vehicles.md
@@ -65,7 +65,7 @@ You can wake up a `VehicleBluetooth` instance using the `wake_up` method. Here's
 ```python
 import asyncio
 from tesla_fleet_api import TeslaBluetooth
-from tesla_fleet_api.exceptions import BluetoothTimeout
+from tesla_fleet_api.exceptions import BluetoothTimeout, TeslaFleetError
 
 async def main():
     tesla_bluetooth = TeslaBluetooth()
@@ -76,6 +76,8 @@ async def main():
         await vehicle.wake_up()
     except BluetoothTimeout:
         pass
+    except TeslaFleetError as e:
+        print(e)
     print(f"Sent wake request to VehicleBluetooth instance for VIN: {vehicle.vin}")
 
 asyncio.run(main())
@@ -88,6 +90,14 @@ backoff. The infotainment computer can also take longer to become ready than
 the vehicle-security computer, so INFO-domain reads immediately after waking
 should retry `BluetoothTimeout` with backoff. Keep one BLE connection open
 across related commands when possible instead of reconnecting for each command.
+
+`VehicleBluetooth` raises `BluetoothTransportError`, a `TeslaFleetError`
+subclass, when the BLE connection or GATT command write fails before a vehicle
+response can be awaited. The original `bleak.exc.BleakError` is available as
+the exception's `__cause__`. Catch `TeslaFleetError` to handle both transport
+failures and response-wait `BluetoothTimeout` failures with one library error
+hierarchy, or catch `BluetoothTransportError` separately when you need to
+distinguish a transport failure from a vehicle timeout.
 
 ## Climate Commands
 

--- a/tesla_fleet_api.egg-info/PKG-INFO
+++ b/tesla_fleet_api.egg-info/PKG-INFO
@@ -189,6 +189,12 @@ asyncio.run(main())
 
 For more detailed examples, see [Bluetooth for Vehicles](docs/bluetooth_vehicles.md).
 
+BLE connect and GATT write failures from `VehicleBluetooth` raise
+`BluetoothTransportError`, a `TeslaFleetError` subclass, with the original
+`bleak.exc.BleakError` chained as `__cause__`. Catch `TeslaFleetError` to
+handle Bluetooth transport failures and `BluetoothTimeout` response-wait
+timeouts through the same library error hierarchy.
+
 ### Routing and Failover
 
 The `Router` class composes an ordered list of two-or-more backends that share a common method surface and dispatches each method call down the chain, automatically failing over on error. `VehicleRouter` and `EnergySiteRouter` are thin entity-specific subclasses. A common setup is a local `VehicleBluetooth` primary with a cloud fallback (e.g. a `TeslemetryVehicle`), so commands go over Bluetooth when the vehicle is reachable and route to the cloud otherwise:

--- a/tesla_fleet_api/exceptions.py
+++ b/tesla_fleet_api/exceptions.py
@@ -28,6 +28,14 @@ class BluetoothTimeout(TeslaFleetError):
     message = "Bluetooth command timed out waiting for vehicle response."
 
 
+class BluetoothTransportError(TeslaFleetError):
+    """The Bluetooth transport (connect or GATT write) failed before a vehicle response could be awaited."""
+
+    message = (
+        "The Bluetooth transport failed before a vehicle response could be awaited."
+    )
+
+
 class ResponseError(TeslaFleetError):
     """The response from the server was not JSON."""
 

--- a/tesla_fleet_api/tesla/vehicle/bluetooth.py
+++ b/tesla_fleet_api/tesla/vehicle/bluetooth.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any, Callable, Generic, TypeVar
 from bleak import BleakClient, BleakScanner
 from bleak.backends.characteristic import BleakGATTCharacteristic
 from bleak.backends.device import BLEDevice
+from bleak.exc import BleakError
 from bleak_retry_connector import MAX_CONNECT_ATTEMPTS, establish_connection
 from cryptography.hazmat.primitives.asymmetric import ec
 from google.protobuf.message import DecodeError
@@ -17,6 +18,7 @@ from tesla_fleet_api.const import LOGGER, BluetoothVehicleData
 from tesla_fleet_api.exceptions import (
     WHITELIST_OPERATION_STATUS,
     BluetoothTimeout,
+    BluetoothTransportError,
     WhitelistOperationStatus,
 )
 from tesla_fleet_api.tesla.vehicle.commands import Commands
@@ -174,7 +176,13 @@ class ReassemblingBuffer:
 
 
 class VehicleBluetooth(Commands[BluetoothParentT], Generic[BluetoothParentT]):
-    """Class describing the Tesla Fleet API vehicle endpoints and commands for a specific vehicle with command signing."""
+    """Class describing the Tesla Fleet API vehicle endpoints and commands for a specific vehicle with command signing.
+
+    Callers can catch failures from this class with a single ``TeslaFleetError``:
+    connect/write transport failures surface as ``BluetoothTransportError`` and
+    a response-wait timeout as ``BluetoothTimeout``, both ``TeslaFleetError``
+    subclasses with the original transport exception chained as their cause.
+    """
 
     ble_name: str
     device: BLEDevice | None = None
@@ -239,15 +247,18 @@ class VehicleBluetooth(Commands[BluetoothParentT], Generic[BluetoothParentT]):
         """Connect to the Tesla BLE device."""
         if not self.device:
             raise ValueError(f"BLEDevice {self.ble_name} has not been found or set")
-        self.client = await establish_connection(
-            BleakClient,
-            self.device,
-            self.vin,
-            max_attempts=max_attempts,
-            # ble_device_callback=self.get_device,
-            services=[SERVICE_UUID],
-        )
-        await self.client.start_notify(READ_UUID, self._on_notify)
+        try:
+            self.client = await establish_connection(
+                BleakClient,
+                self.device,
+                self.vin,
+                max_attempts=max_attempts,
+                # ble_device_callback=self.get_device,
+                services=[SERVICE_UUID],
+            )
+            await self.client.start_notify(READ_UUID, self._on_notify)
+        except BleakError as e:
+            raise BluetoothTransportError from e
 
     async def disconnect(self) -> bool:
         """Disconnect from the Tesla BLE device."""
@@ -322,7 +333,10 @@ class VehicleBluetooth(Commands[BluetoothParentT], Generic[BluetoothParentT]):
 
             await self.connect_if_needed()
             assert self.client is not None
-            await self.client.write_gatt_char(WRITE_UUID, payload, True)
+            try:
+                await self.client.write_gatt_char(WRITE_UUID, payload, True)
+            except BleakError as e:
+                raise BluetoothTransportError from e
 
             # Process the response
             try:

--- a/tests/test_ble_send_transport.py
+++ b/tests/test_ble_send_transport.py
@@ -10,11 +10,12 @@ exercise the real wait/ACK-follow-up state machine without a BLE connection.
 from __future__ import annotations
 
 from unittest import IsolatedAsyncioTestCase
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
+from bleak.exc import BleakError
 from cryptography.hazmat.primitives.asymmetric import ec
 
-from tesla_fleet_api.exceptions import BluetoothTimeout
+from tesla_fleet_api.exceptions import BluetoothTimeout, BluetoothTransportError
 from tesla_fleet_api.tesla.vehicle.bluetooth import VehicleBluetooth
 from tesla_fleet_api.tesla.vehicle.proto.universal_message_pb2 import (
     Destination,
@@ -158,3 +159,54 @@ class SendTimeoutTests(IsolatedAsyncioTestCase):
 
         with self.assertRaises(BluetoothTimeout):
             await vehicle._send(msg, "protobuf_message_as_bytes", timeout=0.05)
+
+
+class SendTransportErrorTests(IsolatedAsyncioTestCase):
+    async def test_mid_write_gatt_failure_raises_bluetooth_transport_error(
+        self,
+    ) -> None:
+        vehicle = _make_vehicle()
+        msg = _outgoing()
+        underlying = BleakError("write failed")
+        vehicle.client.write_gatt_char = AsyncMock(side_effect=underlying)
+
+        with self.assertRaises(BluetoothTransportError) as ctx:
+            await vehicle._send(msg, "protobuf_message_as_bytes")
+
+        self.assertIs(ctx.exception.__cause__, underlying)
+
+
+class ConnectTransportErrorTests(IsolatedAsyncioTestCase):
+    async def test_establish_connection_failure_raises_bluetooth_transport_error(
+        self,
+    ) -> None:
+        parent = MagicMock()
+        parent.private_key = ec.generate_private_key(ec.SECP256R1())
+        vehicle = VehicleBluetooth(parent, VIN)
+        vehicle.device = MagicMock()
+        underlying = BleakError("connect failed")
+
+        with patch(
+            "tesla_fleet_api.tesla.vehicle.bluetooth.establish_connection",
+            AsyncMock(side_effect=underlying),
+        ):
+            with self.assertRaises(BluetoothTransportError) as ctx:
+                await vehicle.connect()
+
+        self.assertIs(ctx.exception.__cause__, underlying)
+
+    async def test_connect_if_needed_propagates_transport_error(self) -> None:
+        parent = MagicMock()
+        parent.private_key = ec.generate_private_key(ec.SECP256R1())
+        vehicle = VehicleBluetooth(parent, VIN)
+        vehicle.device = MagicMock()
+        underlying = BleakError("connect failed")
+
+        with patch(
+            "tesla_fleet_api.tesla.vehicle.bluetooth.establish_connection",
+            AsyncMock(side_effect=underlying),
+        ):
+            with self.assertRaises(BluetoothTransportError) as ctx:
+                await vehicle.connect_if_needed()
+
+        self.assertIs(ctx.exception.__cause__, underlying)


### PR DESCRIPTION
## Intent

- Wrap BLE transport-layer failures in a `TeslaFleetError` subclass so callers get one catchable hierarchy
  - Evidence: scout report `tfa-ble-edgecase-rel-n4` §2a-2 (deterministic, real `_send`) — a mid-write GATT failure (`write_gatt_char`, before the `asyncio.timeout` guard) and a `connect`/`connect_if_needed` failure both propagated as raw `bleak.exc.BleakError`, uncaught by `except TeslaFleetError`. Only the response-wait timeout was wrapped (`BluetoothTimeout`).
- Fix approach: exception wrapping only — no retry changes, no timeout changes, no other behavior changes
  - Added `BluetoothTransportError(TeslaFleetError)` in `exceptions.py`
  - Wrapped the `connect()` `BleakError` path (which `connect_if_needed()` also goes through) and the mid-command `write_gatt_char` `BleakError` path in `_send()`, both re-raising `from e` to preserve the chained cause
  - Updated the `VehicleBluetooth` class docstring and one line in `AGENTS.md` (the existing "catch `TeslaFleetError` or `BaseException`" guidance) to state the new catch contract
- Implication: behavioral change to flag for reviewers
  - Callers previously catching raw `BleakError` directly will now see `BluetoothTransportError` instead, with the original `BleakError` chained as `__cause__`
- Scope boundaries (deliberately not done)
  - `aioesphomeapi` errors are left unwrapped — `aioesphomeapi` is not a dependency of this library (only reachable transitively via an ESPHome BLE proxy), so there is no clean import path without adding a new dependency; accepted scope boundary, not an oversight
  - No retry/timeout logic changed; purely an exception-type change

## What Changed
- Added `BluetoothTransportError`, a `TeslaFleetError` subclass, and wrapped BLE connection and GATT write `BleakError` failures so callers can catch transport failures through the library error hierarchy while preserving the original cause.
- Updated BLE documentation to describe the new wrapped transport-error contract for `VehicleBluetooth` callers.
- Expanded BLE send transport tests to cover write failures, connect failures, and `connect_if_needed()` propagation.

## Risk Assessment

✅ Low: The change is tightly scoped to wrapping existing BLE connect/write transport failures in the library exception hierarchy, preserves exception causes, and adds focused regression coverage without broad behavioral churn.

## Testing

Exercised the targeted BLE transport tests, the full pytest suite, and a consumer-style runtime probe showing both GATT write and connect failures are caught by `except TeslaFleetError` as `BluetoothTransportError` with the original `BleakError` preserved as `__cause__`; all checks passed.

<details>
<summary>Evidence: BLE transport catch-contract transcript</summary>

```text
write failure caught by except TeslaFleetError
  wrapped type: BluetoothTransportError
  original cause: BleakError: write failed
connect_if_needed failure caught by except TeslaFleetError
  wrapped type: BluetoothTransportError
  original cause: BleakError: connect failed
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `uv run pytest tests/test_ble_send_transport.py -q`
- `uv run pytest tests -q`
- `uv run python - <<'PY' | tee /tmp/no-mistakes-evidence/01KX4DTQ8YYQRAEXN51K8QWVB9/ble_transport_error_contract.txt`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>Full narrative / original brief</summary>

Wrap BLE transport-layer failures in a TeslaFleetError subclass so callers get one catchable hierarchy. Evidence (scout report tfa-ble-edgecase-rel-n4, section 2a-2, deterministic real _send probes): a mid-write GATT failure (write_gatt_char, bluetooth.py, before the asyncio.timeout guard) and a connect_if_needed/connect failure both propagated as raw bleak.exc.BleakError, not caught by 'except TeslaFleetError'. Only the response-wait timeout was wrapped (BluetoothTimeout). This is a small, scoped hardening PR (exception wrapping ONLY - no retry changes, no timeout changes, no other behavior changes): added BluetoothTransportError(TeslaFleetError) in exceptions.py, wrapped the connect() BleakError path (which connect_if_needed() also goes through) and the mid-command write_gatt_char BleakError path in _send(), both re-raising 'from e' to preserve the chained cause. Deliberately left aioesphomeapi errors unwrapped since aioesphomeapi is not a dependency of this library (only reachable transitively via an ESPHome BLE proxy) and there's no clean import path without adding a new dependency - this is a known, accepted scope boundary, not an oversight. Updated the VehicleBluetooth class docstring and one line in AGENTS.md (the existing 'catch TeslaFleetError or BaseException' guidance) to state the new catch contract - callers catching just TeslaFleetError now also catch BLE transport failures, not only BluetoothTimeout. This is a behavioral change worth flagging: callers who were previously catching raw BleakError directly will now see BluetoothTransportError instead (with the original BleakError chained as __cause__). Added 3 new tests to tests/test_ble_send_transport.py using the existing mocked-transport pattern (mocked GATT client / mocked establish_connection) covering: the mid-write GATT failure path, the connect() establish_connection failure path, and confirming connect_if_needed() propagates the same wrapped error. Ran ruff check, ruff format, pyright (strict), and the full pytest suite locally - all clean/passing (156 tests).

</details>
