### PR TITLE
Bump version to 1.6.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.6.3"
+version = "1.6.4"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.6.3"
+__version__ = "1.6.4"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.tesla.bluetooth import TeslaBluetooth


### PR DESCRIPTION
## Intent
- Ship release **1.6.4**: PR #64 (command debug logging) merged to `main` but was never released on top of published 1.6.3.
  - Captain-authorized release cut, no functional changes in this PR.

## What Changed
- Bump `version` in `pyproject.toml`: `1.6.3` -> `1.6.4`
- Bump `__version__` in `tesla_fleet_api/__init__.py`: `1.6.3` -> `1.6.4`
- Verified no other `1.6.3` version pins exist elsewhere in the repo (grep clean).

## Risk Assessment
- None: version-only bump, no code changes.

## Testing
- N/A - no functional changes.

## Release Flow
- On merge, a maintainer tags the merge commit `v1.6.4` and pushes the tag, which triggers `.github/workflows/python-publish.yml` to build and publish to PyPI.

<details><summary>Full narrative / original brief</summary>

Cut python-tesla-fleet-api release 1.6.4. Captain-authorized: main's merged command debug-logging (PR #64) is unreleased on top of published 1.6.3.

Do, in order:
1. Branch off origin/main. Bump the version to 1.6.4 in BOTH pyproject.toml and tesla_fleet_api/__init__.py (verify no other version pins exist - grep for 1.6.3).
2. Open the bump PR and append `done: PR {url} - awaiting merge, then I tag`. STOP and wait.
3. Firstmate will merge and steer you to continue. THEN: fetch origin, verify the bump commit is in origin/main, tag that main commit `v1.6.4` and push the tag to origin (the tag push is authorized - it is how python-publish.yml ships to PyPI; you are still never pushing the main branch itself).
4. Watch the publish workflow (gh run list/watch) until it completes, then verify https://pypi.org/pypi/tesla-fleet-api/json reports 1.6.4.
5. Append `done: 1.6.4 on PyPI` and stop. If the workflow fails, append `failed:` with the run URL and stop.

</details>
