### PR TITLE
chore: bump version to 1.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.6.4"
+version = "1.7.0"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.6.4"
+__version__ = "1.7.0"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.tesla.bluetooth import TeslaBluetooth


### PR DESCRIPTION
## Intent

Cut the python-tesla-fleet-api release now that BLE confirmation work is locked (PR 68 merged). Bump version 1.6.4 -> 1.7.0 (minor) in pyproject.toml and tesla_fleet_api/__init__.py only - no other code changes. Version choice rationale: main since 1.6.4 includes BluetoothUnconfirmedCommand (PR 66), the optimistic/raise_unconfirmed knobs (PR 67), and the broadcast-confirmation ladder + confirmation enum + raise_unconfirmed default flip + BluetoothCommandFailed (PR 68) - a default behavior flip and new deprecating-but-shimmed enum. Checked repo history: every prior version bump since 1.6.0 was a PATCH bump per individual PR merged (including feat commits), and minor bumps (e.g. 1.4.7->1.5.0) were historically used even for a breaking change (dropping Python 3.10 support) - the repo has never used a major bump in its entire history. So minor (1.7.0) is the correct and unambiguous choice per this repo's own versioning practice, not a guess. This PR is intentionally scoped to ONLY the version bump - after it merges to main, a vX.Y.Z tag will be pushed separately to trigger python-publish.yml -> PyPI (tag push is the actual release trigger, not the merge).

## What Changed

- Bumped the package version from `1.6.4` to `1.7.0` in `pyproject.toml`.
- Updated `tesla_fleet_api.__version__` to `1.7.0` so the runtime package metadata stays aligned with the distribution version.

## Risk Assessment

✅ Low: The reviewed change is a narrow, consistent version bump in the two files specified by the project release process, with no code-path or packaging-workflow changes introduced.

## Testing

Checked the baseline diff scope, verified the installed/imported package version and built wheel metadata as end-user release evidence, corrected an environment-only missing `python` alias by rerunning with `uv run python`, ran the full pytest suite, saved evidence under `/tmp/no-mistakes-evidence/01KXA8WTQ2T9AZQ7QAPBQ465B3`, and removed transient worktree build/cache artifacts afterward.

<details>
<summary>Evidence: Version release evidence</summary>

<code>Shows the committed diff is limited to `pyproject.toml` and `tesla_fleet_api/__init__.py`, and both runtime surfaces report `1.7.0`.</code>

```text
$ git diff --name-only fcaed9edc6582684d89ea38e8ab45cc598cd017f..753deacc0da0e58309002435c29fe55508a96104
pyproject.toml
tesla_fleet_api/__init__.py

$ git diff --unified=0 fcaed9edc6582684d89ea38e8ab45cc598cd017f..753deacc0da0e58309002435c29fe55508a96104 -- pyproject.toml tesla_fleet_api/__init__.py
diff --git a/pyproject.toml b/pyproject.toml
index f446bcc..e4c5ed4 100644
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7 +7 @@ name = "tesla_fleet_api"
-version = "1.6.4"
+version = "1.7.0"
diff --git a/tesla_fleet_api/__init__.py b/tesla_fleet_api/__init__.py
index 7b6972c..7306966 100644
--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -4 +4 @@ __author__ = "hello@teslemetry.com"
-__version__ = "1.6.4"
+__version__ = "1.7.0"

$ uv run python -c "import importlib.metadata as md; import tesla_fleet_api; print(...)"
tesla_fleet_api.__version__ = 1.7.0
installed distribution version = 1.7.0
```
</details>
<details>
<summary>Evidence: Wheel metadata evidence</summary>

<code>Shows the built wheel filename and wheel METADATA both carry `Version: 1.7.0`.</code>

```text
$ uv build --wheel --out-dir /tmp/no-mistakes-evidence/01KXA8WTQ2T9AZQ7QAPBQ465B3/dist

$ uv run python -m zipfile -l "$WHEEL" | sed -n "/METADATA/p"
tesla_fleet_api-1.7.0.dist-info/METADATA       2026-07-12 04:23:20        13073

$ uv run python - <<PY  # read wheel METADATA version
wheel file = tesla_fleet_api-1.7.0-py3-none-any.whl
Name: tesla_fleet_api
Version: 1.7.0
```
</details>
- Evidence: Built wheel artifact (local file: <code>/tmp/no-mistakes-evidence/01KXA8WTQ2T9AZQ7QAPBQ465B3/dist/tesla_fleet_api-1.7.0-py3-none-any.whl</code>)
<details>
<summary>Evidence: Pytest transcript</summary>

<code>Full test-suite transcript for `uv run pytest tests`.</code>

```text
============================= test session starts ==============================
platform linux -- Python 3.14.5, pytest-9.1.0, pluggy-1.6.0
rootdir: /home/brett/.no-mistakes/worktrees/cbd01a0d6989/01KXA8WTQ2T9AZQ7QAPBQ465B3
configfile: pyproject.toml
collected 281 items

tests/test_auto_seat_climate.py ....                                     [  1%]
tests/test_ble_broadcast_confirmation.py .............                   [  6%]
tests/test_ble_charging_commands.py ...................                  [ 12%]
tests/test_ble_climate_commands.py ..................                    [ 19%]
tests/test_ble_command_verification.py .................                 [ 25%]
tests/test_ble_confirmation_mode.py ..................                   [ 31%]
tests/test_ble_expects_data.py ....                                      [ 33%]
tests/test_ble_keepalive.py ...........                                  [ 37%]
tests/test_ble_message_routing.py .....                                  [ 38%]
tests/test_ble_mocked_closures_locks.py .....                            [ 40%]
tests/test_ble_mocked_commands.py ...                                    [ 41%]
tests/test_ble_mocked_media_commands.py .........                        [ 44%]
tests/test_ble_mocked_state_readers.py ..............                    [ 49%]
tests/test_ble_nav_misc_commands.py ...........                          [ 53%]
tests/test_ble_optimistic_and_best_effort.py ...............             [ 59%]
tests/test_ble_pair.py ........                                          [ 61%]
tests/test_ble_reassembling_buffer.py .......                            [ 64%]
tests/test_ble_send_transport.py ................                        [ 70%]
tests/test_ble_unconfirmed_command.py ...........                        [ 74%]
tests/test_command_counter_lock.py .                                     [ 74%]
tests/test_command_logging.py ............                               [ 78%]
tests/test_cross_transport_parity.py ....                                [ 80%]
tests/test_find_vehicle_scan_filter.py ..                                [ 80%]
tests/test_firmware_at_least.py ...........                              [ 84%]
tests/test_fleet_auth_refresh.py ......                                  [ 86%]
tests/test_power_mode_commands.py ....                                   [ 88%]
tests/test_router.py ............................                        [ 98%]
tests/test_tessie_vehicle_params.py .....                                [100%]

============================= 281 passed in 2.33s ==============================
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --name-only fcaed9edc6582684d89ea38e8ab45cc598cd017f..753deacc0da0e58309002435c29fe55508a96104`
- `git diff --unified=0 fcaed9edc6582684d89ea38e8ab45cc598cd017f..753deacc0da0e58309002435c29fe55508a96104 -- pyproject.toml tesla_fleet_api/__init__.py`
- `uv run python -c "import importlib.metadata as md; import tesla_fleet_api; print('tesla_fleet_api.__version__ =', tesla_fleet_api.__version__); print('installed distribution version =', md.version('tesla_fleet_api'))"`
- `uv build --wheel --out-dir /tmp/no-mistakes-evidence/01KXA8WTQ2T9AZQ7QAPBQ465B3/dist`
- `uv run python -m zipfile -l "$WHEEL" | sed -n '/METADATA/p'`
- `WHEEL="$WHEEL" uv run python - <<'PY' ... read wheel METADATA Name/Version ... PY`
- `uv run pytest tests`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
