### PR TITLE
chore: bump release version to 1.7.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.7.0"
+version = "1.7.1"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.7.0"
+__version__ = "1.7.1"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.tesla.bluetooth import TeslaBluetooth

--- a/uv.lock
+++ b/uv.lock
@@ -728,7 +728,7 @@ wheels = [
 
 [[package]]
 name = "tesla-fleet-api"
-version = "1.7.0"
+version = "1.7.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Intent

Version-bump-only release PR to cut 1.7.1. PR #70 (the BLE write-timeout delivery-certainty classification fix, plus the get_private_key 0600 PEM permissions fix) was just merged to main by the captain. This branch is based fresh on origin/main (includes PR #70) with exactly one additional commit: bump version from 1.7.0 to 1.7.1 in pyproject.toml's [project] version field and tesla_fleet_api/__init__.py's __version__ constant, nothing else changed. This follows the repo's documented release process (AGENTS.md 'Release Process' section, no release-please automation): merge the version-bump commit to main, then push a matching vX.Y.Z tag separately (tag push is what actually triggers python-publish.yml to build+publish to PyPI and create a GitHub Release - merging alone does not publish). No CHANGELOG.md exists in this repo to update. This is intentionally a minimal, mechanical diff - do not expect or want any behavioral changes, new tests, or doc updates in this PR.

## What Changed

- Bumped the package release version from `1.7.0` to `1.7.1` in `pyproject.toml` and `tesla_fleet_api/__init__.py`.
- Updated `uv.lock` so the editable package metadata matches the new `1.7.1` release version.

## Risk Assessment

✅ Low: The diff is limited to a coordinated 1.7.1 version bump in pyproject.toml, tesla_fleet_api/__init__.py, and uv.lock, with no behavioral code changes or remaining lockfile mismatch.

## Testing

Inspected the release-bump diff, built wheel and sdist artifacts, verified pyproject/importlib/runtime/lock/wheel/sdist metadata all report 1.7.1, installed the wheel from a clean temporary venv to confirm end-user import behavior, and ran `uv run pytest tests`; all checks passed, and transient worktree build/venv/cache outputs were removed.

- Evidence: Built wheel (local file: <code>/tmp/no-mistakes-evidence/01KXANFMA69KB0DTXKDYZRV1H2/dist/tesla_fleet_api-1.7.1-py3-none-any.whl</code>)
- Evidence: Built source distribution (local file: <code>/tmp/no-mistakes-evidence/01KXANFMA69KB0DTXKDYZRV1H2/dist/tesla_fleet_api-1.7.1.tar.gz</code>)
<details>
<summary>Evidence: Version metadata evidence</summary>

```text
pyproject.toml project.version: 1.7.1
tesla_fleet_api.__version__ from worktree import: 1.7.1
importlib.metadata.version("tesla_fleet_api"): 1.7.1
uv.lock editable package version is 1.7.1: True
wheel filename: tesla_fleet_api-1.7.1-py3-none-any.whl
wheel METADATA Version: 1.7.1
wheel tesla_fleet_api.__init__ has __version__ 1.7.1: True
sdist filename: tesla_fleet_api-1.7.1.tar.gz
sdist pyproject.toml project.version: 1.7.1
```
</details>
<details>
<summary>Evidence: Clean wheel install evidence</summary>

```text
imported module path: /tmp/tfa-171-wheel-venv-01KXANFMA69KB0DTXKDYZRV1H2/lib/python3.14/site-packages/tesla_fleet_api/__init__.py
imported tesla_fleet_api.__version__: 1.7.1
installed distribution version: 1.7.1
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- ⚠️ `pyproject.toml:7` - The project version was bumped to 1.7.1, but the tracked lockfile still records the editable package as 1.7.0, so `uv lock --check` now fails with “lockfile ... needs to be updated.” Regenerate and commit `uv.lock` so locked installs/checks remain valid.

🔧 Fix: Update uv lock release version
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 09a0bf86e4a7a7eab6db32da4b021552a21163e2..ff41ecb84d5e0f5675ee839fcf3834da98f2665f -- pyproject.toml tesla_fleet_api/__init__.py uv.lock`
- `uv build --out-dir /tmp/no-mistakes-evidence/01KXANFMA69KB0DTXKDYZRV1H2/dist`
- `uv run python - <<'PY' | tee /tmp/no-mistakes-evidence/01KXANFMA69KB0DTXKDYZRV1H2/logs/version-evidence.txt`
- `uv run pytest tests`
- `uv venv /tmp/tfa-171-wheel-venv-01KXANFMA69KB0DTXKDYZRV1H2 && uv pip install --python /tmp/tfa-171-wheel-venv-01KXANFMA69KB0DTXKDYZRV1H2/bin/python /tmp/no-mistakes-evidence/01KXANFMA69KB0DTXKDYZRV1H2/dist/tesla_fleet_api-1.7.1-py3-none-any.whl && cd /tmp/no-mistakes-evidence/01KXANFMA69KB0DTXKDYZRV1H2 && /tmp/tfa-171-wheel-venv-01KXANFMA69KB0DTXKDYZRV1H2/bin/python - <<'PY' ...`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
