### PR TITLE
fix(tesla): create private keys atomically with owner-only permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,12 @@ asyncio.run(main())
 
 For more detailed examples, see [Bluetooth for Vehicles](docs/bluetooth_vehicles.md).
 
+`get_private_key(path)` loads an existing EC private key or creates a new
+unencrypted PEM key file. Newly created key files are created owner-readable
+and owner-writable only (`0600`) from the start, with no write-then-chmod
+window, and concurrent creators fall back to reading the file that won the
+create race.
+
 `VehicleBluetooth` keeps a held BLE connection alive during idle periods by
 default with a passive GATT read about every 20 seconds. Pass
 `keepalive_interval=None` (or `0`) when creating the vehicle to disable it;

--- a/docs/bluetooth_vehicles.md
+++ b/docs/bluetooth_vehicles.md
@@ -39,6 +39,12 @@ async def main():
 asyncio.run(main())
 ```
 
+`get_private_key(path)` loads an existing EC private key or creates a new
+unencrypted PEM key file. Newly created key files are created owner-readable
+and owner-writable only (`0600`) from the start, with no write-then-chmod
+window, and concurrent creators fall back to reading the file that won the
+create race.
+
 ## Keeping the Connection Alive (`keepalive_interval`)
 
 An idle held BLE link to the vehicle drops on its own after roughly 42 seconds

--- a/docs/fleet_api_energy_sites.md
+++ b/docs/fleet_api_energy_sites.md
@@ -354,6 +354,12 @@ asyncio.run(main())
 
 Energy gateways (Powerwalls, etc.) support gRPC commands sent via `POST /api/1/energy_sites/{id}/command`. These are undocumented Tesla API endpoints that communicate directly with the gateway hardware. All device command methods require the `energy_cmds` scope.
 
+`get_rsa_private_key(path)` loads an existing RSA private key for gateway
+client registration or creates a new unencrypted PEM key file. Newly created
+key files are created owner-readable and owner-writable only (`0600`) from the
+start, with no write-then-chmod window, and concurrent creators fall back to
+reading the file that won the create race.
+
 ### Available Commands
 
 | Method | Category | Description |

--- a/tesla_fleet_api.egg-info/PKG-INFO
+++ b/tesla_fleet_api.egg-info/PKG-INFO
@@ -189,6 +189,12 @@ asyncio.run(main())
 
 For more detailed examples, see [Bluetooth for Vehicles](docs/bluetooth_vehicles.md).
 
+`get_private_key(path)` loads an existing EC private key or creates a new
+unencrypted PEM key file. Newly created key files are created owner-readable
+and owner-writable only (`0600`) from the start, with no write-then-chmod
+window, and concurrent creators fall back to reading the file that won the
+create race.
+
 `VehicleBluetooth` keeps a held BLE connection alive during idle periods by
 default with a passive GATT read about every 20 seconds. Pass
 `keepalive_interval=None` (or `0`) when creating the vehicle to disable it;

--- a/tesla_fleet_api.egg-info/PKG-INFO
+++ b/tesla_fleet_api.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: tesla_fleet_api
-Version: 1.6.4
+Version: 1.7.1
 Summary: Tesla Fleet API library for Python
 Author-email: Brett Adams <hello@teslemetry.com>
 License-Expression: Apache-2.0
@@ -195,15 +195,17 @@ default with a passive GATT read about every 20 seconds. Pass
 leaving it enabled can keep an already-awake car awake longer, so disconnect or
 disable keepalive when vehicle sleep is preferred.
 
-BLE connect/notify and GATT write failures from `VehicleBluetooth` raise
+BLE connect/notify failures, and GATT writes rejected before backend I/O, raise
 `BluetoothTransportError`, a `TeslaFleetError` subclass, with the original
-transport exception chained as `__cause__`. By default, a response-wait timeout
-from a mutating BLE command raises `BluetoothUnconfirmedCommand`, a
-`BluetoothTimeout` subclass, because the vehicle may have executed it despite a
-lost acknowledgement. The BLE-only `optimistic` and `raise_unconfirmed`
-factory options can instead resolve some ambiguous timeouts as best-effort
-successes; see [Bluetooth for Vehicles](docs/bluetooth_vehicles.md) for the
-full confirmation ladder. Catch `TeslaFleetError` to handle Bluetooth transport
+transport exception chained as `__cause__` when available. A GATT write that
+entered backend I/O and then failed or timed out is delivery-ambiguous and
+raises `BluetoothTimeout`/`BluetoothUnconfirmedCommand` instead. Mutating BLE
+commands use a confirmation ladder controlled by `confirmation` (`"ack"` by
+default) and `raise_unconfirmed` (`False` by default): an inconclusive lost
+acknowledgement resolves as best-effort success unless you opt in to
+`BluetoothUnconfirmedCommand`, while a command proven not to have applied raises
+`BluetoothCommandFailed`. See [Bluetooth for Vehicles](docs/bluetooth_vehicles.md)
+for the full ladder. Catch `TeslaFleetError` to handle Bluetooth transport
 failures (including `bleak.exc.BleakError` and builtin `TimeoutError` from
 ESPHome proxies) and response-wait timeouts through the same library error
 hierarchy.
@@ -224,7 +226,7 @@ async def main():
         # Primary: local Bluetooth
         tesla_bluetooth = TeslaBluetooth()
         await tesla_bluetooth.get_private_key("path/to/private_key.pem")
-        primary = tesla_bluetooth.vehicles.create("<vin>", verify_commands=True)
+        primary = tesla_bluetooth.vehicles.create("<vin>", confirmation="verify")
 
         # Secondary (fallback): Teslemetry cloud
         teslemetry = Teslemetry(access_token="<access_token>", session=session)
@@ -257,7 +259,7 @@ await router.set_operation(...)  # local first, cloud on failure
 
 Enable `DEBUG` logging for `tesla_fleet_api` to see which backend served a routed call and why failover happened.
 
-> **Warning:** Because a failed call is replayed on the next backend, a non-idempotent command (e.g. `honk_horn`, `actuate_trunk`, `door_unlock`, `charge_start`) that fails _mid-flight_ — after a backend may have already partially applied it — can be **double-executed** (or executed more than once across a longer chain) when it is retried on the next backend. This is a deliberate tradeoff of per-command failover. `BluetoothUnconfirmedCommand` is the exception: it propagates without failover because the BLE command may already have executed. When the primary is `VehicleBluetooth`, pass `verify_commands=True` to resolve supported mutating command timeouts by state before they reach the router, or `raise_unconfirmed=False` only when a best-effort success is acceptable; callers needing exactly-once semantics for other commands should gate dispatch with an explicit `health` check or call the underlying backends directly.
+> **Warning:** Because a failed call is replayed on the next backend, a non-idempotent command (e.g. `honk_horn`, `actuate_trunk`, `door_unlock`, `charge_start`) that fails _mid-flight_ — after a backend may have already partially applied it — can be **double-executed** (or executed more than once across a longer chain) when it is retried on the next backend. This is a deliberate tradeoff of per-command failover. `BluetoothUnconfirmedCommand` is the exception: it propagates without failover because the BLE command may already have executed. When the primary is `VehicleBluetooth`, pass `confirmation="verify"` to resolve supported mutating command timeouts by state before they reach the router, and set `raise_unconfirmed=True` when callers must see still-ambiguous outcomes instead of the default best-effort success; callers needing exactly-once semantics for other commands should gate dispatch with an explicit `health` check or call the underlying backends directly.
 >
 > Dispatch is implemented via `__getattr__`, which does not proxy dunder methods, so `async with Router(...)` does **not** manage a backend's BLE connection lifecycle (`__aenter__`/`__aexit__`). Commands still auto-connect on send; for explicit connect/disconnect reach through `router.primary` (or `router.backends`).
 

--- a/tesla_fleet_api.egg-info/SOURCES.txt
+++ b/tesla_fleet_api.egg-info/SOURCES.txt
@@ -61,9 +61,11 @@ tesla_fleet_api/tessie/__init__.py
 tesla_fleet_api/tessie/tessie.py
 tesla_fleet_api/tessie/vehicle.py
 tests/test_auto_seat_climate.py
+tests/test_ble_broadcast_confirmation.py
 tests/test_ble_charging_commands.py
 tests/test_ble_climate_commands.py
 tests/test_ble_command_verification.py
+tests/test_ble_confirmation_mode.py
 tests/test_ble_expects_data.py
 tests/test_ble_keepalive.py
 tests/test_ble_message_routing.py
@@ -72,10 +74,12 @@ tests/test_ble_mocked_commands.py
 tests/test_ble_mocked_media_commands.py
 tests/test_ble_mocked_state_readers.py
 tests/test_ble_nav_misc_commands.py
+tests/test_ble_optimistic_and_best_effort.py
 tests/test_ble_pair.py
 tests/test_ble_reassembling_buffer.py
 tests/test_ble_send_transport.py
 tests/test_ble_unconfirmed_command.py
+tests/test_ble_write_timeout_router.py
 tests/test_command_counter_lock.py
 tests/test_command_logging.py
 tests/test_cross_transport_parity.py
@@ -84,4 +88,5 @@ tests/test_firmware_at_least.py
 tests/test_fleet_auth_refresh.py
 tests/test_power_mode_commands.py
 tests/test_router.py
+tests/test_tesla_private_key.py
 tests/test_tessie_vehicle_params.py

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -21,7 +21,11 @@ def _owner_only_opener(file: str, flags: int) -> int:
     """Open a new file exclusively, born at mode 0o600 with no chmod window."""
     fd = os.open(file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
-        os.fchmod(fd, 0o600)
+        fchmod = getattr(os, "fchmod", None)
+        if fchmod is not None:
+            fchmod(fd, 0o600)
+        else:
+            os.chmod(file, 0o600)
     except OSError:
         os.close(fd)
         raise

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -92,9 +92,7 @@ class Tesla:
             except FileExistsError:
                 value = await _load_pem_private_key(path, retry_invalid=True)
                 if not isinstance(value, ec.EllipticCurvePrivateKey):
-                    raise AssertionError(
-                        "Loaded key is not an EllipticCurvePrivateKey"
-                    )
+                    raise AssertionError("Loaded key is not an EllipticCurvePrivateKey")
                 self.private_key = value
                 return self.private_key
 

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -1,7 +1,9 @@
 """Tesla Fleet API for Python."""
 
 import base64
+import asyncio
 import os
+import time
 from os.path import exists
 import aiofiles
 
@@ -15,6 +17,9 @@ from tesla_fleet_api.tesla.vehicle.vehicles import Vehicles
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
+
+_KEY_READ_RETRY_TIMEOUT = 1.0
+_KEY_READ_RETRY_INTERVAL = 0.05
 
 
 def _owner_only_opener(file: str, flags: int) -> int:
@@ -30,6 +35,21 @@ def _owner_only_opener(file: str, flags: int) -> int:
         os.close(fd)
         raise
     return fd
+
+
+async def _load_pem_private_key(path: str, retry_invalid: bool = False) -> object:
+    deadline = time.monotonic() + _KEY_READ_RETRY_TIMEOUT
+    while True:
+        async with aiofiles.open(path, "rb") as key_file:
+            key_data = await key_file.read()
+        try:
+            return serialization.load_pem_private_key(
+                key_data, password=None, backend=default_backend()
+            )
+        except ValueError:
+            if not retry_invalid or time.monotonic() >= deadline:
+                raise
+            await asyncio.sleep(_KEY_READ_RETRY_INTERVAL)
 
 
 class Tesla:
@@ -69,14 +89,16 @@ class Tesla:
                     await key_file.write(pem)
                 return self.private_key
             except FileExistsError:
-                pass
+                value = await _load_pem_private_key(path, retry_invalid=True)
+                if not isinstance(value, ec.EllipticCurvePrivateKey):
+                    raise AssertionError(
+                        "Loaded key is not an EllipticCurvePrivateKey"
+                    )
+                self.private_key = value
+                return self.private_key
 
         try:
-            async with aiofiles.open(path, "rb") as key_file:
-                key_data = await key_file.read()
-            value = serialization.load_pem_private_key(
-                key_data, password=None, backend=default_backend()
-            )
+            value = await _load_pem_private_key(path)
         except FileNotFoundError:
             raise FileNotFoundError(f"Private key file not found at {path}")
         except PermissionError:
@@ -149,13 +171,13 @@ class Tesla:
                     await key_file.write(pem)
                 return self.rsa_private_key
             except FileExistsError:
-                pass
+                value = await _load_pem_private_key(path, retry_invalid=True)
+                if not isinstance(value, rsa.RSAPrivateKey):
+                    raise AssertionError("Loaded key is not an RSAPrivateKey")
+                self.rsa_private_key = value
+                return self.rsa_private_key
 
-        async with aiofiles.open(path, "rb") as key_file:
-            key_data = await key_file.read()
-        value = serialization.load_pem_private_key(
-            key_data, password=None, backend=default_backend()
-        )
+        value = await _load_pem_private_key(path)
         if not isinstance(value, rsa.RSAPrivateKey):
             raise AssertionError("Loaded key is not an RSAPrivateKey")
         self.rsa_private_key = value

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -19,7 +19,13 @@ from cryptography.hazmat.backends import default_backend
 
 def _owner_only_opener(file: str, flags: int) -> int:
     """Open a new file exclusively, born at mode 0o600 with no chmod window."""
-    return os.open(file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    fd = os.open(file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    try:
+        os.fchmod(fd, 0o600)
+    except OSError:
+        os.close(fd)
+        raise
+    return fd
 
 
 class Tesla:

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -69,9 +69,10 @@ class Tesla:
     ) -> ec.EllipticCurvePrivateKey:
         """Get or create the private key.
 
-        A newly created key file is opened with O_EXCL so it is born at mode
-        0o600 with no world-readable window. If another process wins the
-        create race, its file is read instead of raising.
+        The private key is stored as an unencrypted PEM file. A newly created
+        key file is opened with O_EXCL so it is born at mode 0o600 with no
+        world-readable window. If another process wins the create race, its
+        file is read instead of raising.
         """
         if not exists(path):
             self.private_key = ec.generate_private_key(
@@ -148,10 +149,10 @@ class Tesla:
         """Get or create an RSA private key for energy gateway client registration.
 
         The default 4096-bit key matches the format expected by the Powerwall
-        TEDapi v1r LAN protocol. A newly created key file is opened with
-        O_EXCL so it is born at mode 0o600 with no world-readable window. If
-        another process wins the create race, its file is read instead of
-        raising.
+        TEDapi v1r LAN protocol. The private key is stored as an unencrypted
+        PEM file. A newly created key file is opened with O_EXCL so it is born
+        at mode 0o600 with no world-readable window. If another process wins
+        the create race, its file is read instead of raising.
         """
         if not exists(path):
             self.rsa_private_key = rsa.generate_private_key(

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -98,7 +98,7 @@ class Tesla:
                 return self.private_key
 
         try:
-            value = await _load_pem_private_key(path)
+            value = await _load_pem_private_key(path, retry_invalid=True)
         except FileNotFoundError:
             raise FileNotFoundError(f"Private key file not found at {path}")
         except PermissionError:
@@ -177,7 +177,7 @@ class Tesla:
                 self.rsa_private_key = value
                 return self.rsa_private_key
 
-        value = await _load_pem_private_key(path)
+        value = await _load_pem_private_key(path, retry_invalid=True)
         if not isinstance(value, rsa.RSAPrivateKey):
             raise AssertionError("Loaded key is not an RSAPrivateKey")
         self.rsa_private_key = value

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -1,6 +1,7 @@
 """Tesla Fleet API for Python."""
 
 import base64
+import os
 from os.path import exists
 import aiofiles
 
@@ -14,6 +15,11 @@ from tesla_fleet_api.tesla.vehicle.vehicles import Vehicles
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.backends import default_backend
+
+
+def _owner_only_opener(file: str, flags: int) -> int:
+    """Open a new file exclusively, born at mode 0o600 with no chmod window."""
+    return os.open(file, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
 
 
 class Tesla:
@@ -33,42 +39,42 @@ class Tesla:
     ) -> ec.EllipticCurvePrivateKey:
         """Get or create the private key.
 
-        The private key is stored as an unencrypted PEM file with permissions
-        0o600 when created.
+        A newly created key file is opened with O_EXCL so it is born at mode
+        0o600 with no world-readable window. If another process wins the
+        create race, its file is read instead of raising.
         """
         if not exists(path):
             self.private_key = ec.generate_private_key(
                 ec.SECP256R1(), default_backend()
             )
-            # save the key
             pem = self.private_key.private_bytes(
                 encoding=serialization.Encoding.PEM,
                 format=serialization.PrivateFormat.TraditionalOpenSSL,
                 encryption_algorithm=serialization.NoEncryption(),
             )
-            async with aiofiles.open(path, "wb") as key_file:
-                await key_file.write(pem)
             try:
-                from os import chmod
-
-                chmod(path, 0o600)
-            except OSError:
+                async with aiofiles.open(
+                    path, "wb", opener=_owner_only_opener
+                ) as key_file:
+                    await key_file.write(pem)
+                return self.private_key
+            except FileExistsError:
                 pass
-        else:
-            try:
-                async with aiofiles.open(path, "rb") as key_file:
-                    key_data = await key_file.read()
-                value = serialization.load_pem_private_key(
-                    key_data, password=None, backend=default_backend()
-                )
-            except FileNotFoundError:
-                raise FileNotFoundError(f"Private key file not found at {path}")
-            except PermissionError:
-                raise PermissionError(f"Permission denied when trying to read {path}")
 
-            if not isinstance(value, ec.EllipticCurvePrivateKey):
-                raise AssertionError("Loaded key is not an EllipticCurvePrivateKey")
-            self.private_key = value
+        try:
+            async with aiofiles.open(path, "rb") as key_file:
+                key_data = await key_file.read()
+            value = serialization.load_pem_private_key(
+                key_data, password=None, backend=default_backend()
+            )
+        except FileNotFoundError:
+            raise FileNotFoundError(f"Private key file not found at {path}")
+        except PermissionError:
+            raise PermissionError(f"Permission denied when trying to read {path}")
+
+        if not isinstance(value, ec.EllipticCurvePrivateKey):
+            raise AssertionError("Loaded key is not an EllipticCurvePrivateKey")
+        self.private_key = value
         return self.private_key
 
     @property
@@ -110,8 +116,10 @@ class Tesla:
         """Get or create an RSA private key for energy gateway client registration.
 
         The default 4096-bit key matches the format expected by the Powerwall
-        TEDapi v1r LAN protocol. The private key is stored as an unencrypted
-        PEM file with permissions 0o600 when created.
+        TEDapi v1r LAN protocol. A newly created key file is opened with
+        O_EXCL so it is born at mode 0o600 with no world-readable window. If
+        another process wins the create race, its file is read instead of
+        raising.
         """
         if not exists(path):
             self.rsa_private_key = rsa.generate_private_key(
@@ -124,23 +132,23 @@ class Tesla:
                 format=serialization.PrivateFormat.TraditionalOpenSSL,
                 encryption_algorithm=serialization.NoEncryption(),
             )
-            async with aiofiles.open(path, "wb") as key_file:
-                await key_file.write(pem)
             try:
-                from os import chmod
-
-                chmod(path, 0o600)
-            except OSError:
+                async with aiofiles.open(
+                    path, "wb", opener=_owner_only_opener
+                ) as key_file:
+                    await key_file.write(pem)
+                return self.rsa_private_key
+            except FileExistsError:
                 pass
-        else:
-            async with aiofiles.open(path, "rb") as key_file:
-                key_data = await key_file.read()
-            value = serialization.load_pem_private_key(
-                key_data, password=None, backend=default_backend()
-            )
-            if not isinstance(value, rsa.RSAPrivateKey):
-                raise AssertionError("Loaded key is not an RSAPrivateKey")
-            self.rsa_private_key = value
+
+        async with aiofiles.open(path, "rb") as key_file:
+            key_data = await key_file.read()
+        value = serialization.load_pem_private_key(
+            key_data, password=None, backend=default_backend()
+        )
+        if not isinstance(value, rsa.RSAPrivateKey):
+            raise AssertionError("Loaded key is not an RSAPrivateKey")
+        self.rsa_private_key = value
         return self.rsa_private_key
 
     @property

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -9,6 +9,7 @@ winner's file instead of raising.
 
 from __future__ import annotations
 
+import asyncio
 import stat
 import os
 import tempfile
@@ -122,6 +123,28 @@ class GetPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
 
             self.assertEqual(_ec_pem(key), _ec_pem(winner_key))
 
+    async def test_concurrent_create_waits_for_winner_to_finish_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "private_key.pem"
+            winner_key = ec.generate_private_key(ec.SECP256R1())
+            path.touch(mode=0o600)
+
+            async def finish_write() -> None:
+                await asyncio.sleep(0.1)
+                path.write_bytes(_ec_pem(winner_key))
+
+            writer = asyncio.create_task(finish_write())
+            try:
+                loser = Tesla()
+                with mock.patch(
+                    "tesla_fleet_api.tesla.tesla.exists", return_value=False
+                ):
+                    key = await loser.get_private_key(str(path))
+            finally:
+                await writer
+
+            self.assertEqual(_ec_pem(key), _ec_pem(winner_key))
+
 
 class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
     async def test_new_key_file_is_owner_only(self) -> None:
@@ -169,5 +192,30 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             loser = Tesla()
             with mock.patch("tesla_fleet_api.tesla.tesla.exists", return_value=False):
                 key = await loser.get_rsa_private_key(path, key_size=1024)
+
+            self.assertEqual(_rsa_pem(key), _rsa_pem(winner_key))
+
+    async def test_concurrent_create_waits_for_winner_to_finish_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "tedapi_rsa_private.pem"
+            winner_key = rsa.generate_private_key(
+                public_exponent=65537,
+                key_size=1024,
+            )
+            path.touch(mode=0o600)
+
+            async def finish_write() -> None:
+                await asyncio.sleep(0.1)
+                path.write_bytes(_rsa_pem(winner_key))
+
+            writer = asyncio.create_task(finish_write())
+            try:
+                loser = Tesla()
+                with mock.patch(
+                    "tesla_fleet_api.tesla.tesla.exists", return_value=False
+                ):
+                    key = await loser.get_rsa_private_key(str(path), key_size=1024)
+            finally:
+                await writer
 
             self.assertEqual(_rsa_pem(key), _rsa_pem(winner_key))

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -1,10 +1,10 @@
-"""``get_private_key`` must write its PEM file with owner-only permissions.
+"""``get_private_key``/``get_rsa_private_key`` must create their PEM files atomically.
 
-The key it creates signs Tesla vehicle commands (Fleet API and BLE) - written
-with the process default mode (typically group/world-readable), it leaks
-command-signing material to any other local user. ``get_rsa_private_key``
-(the TEDapi/Powerwall key created later in the same module) already chmods to
-0o600 after writing; this locks ``get_private_key`` into the same contract.
+The keys sign Tesla vehicle commands (Fleet API and BLE) and register with the
+Powerwall TEDapi gateway. Both are created via an O_EXCL-opened file at mode
+0o600 so there is never a write-then-chmod window where the key is
+world-readable, and a losing concurrent creator falls back to reading the
+winner's file instead of raising.
 """
 
 from __future__ import annotations
@@ -12,9 +12,28 @@ from __future__ import annotations
 import stat
 import tempfile
 from pathlib import Path
-from unittest import IsolatedAsyncioTestCase
+from unittest import IsolatedAsyncioTestCase, mock
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
 from tesla_fleet_api.tesla.tesla import Tesla
+
+
+def _ec_pem(key: ec.EllipticCurvePrivateKey) -> bytes:
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+
+def _rsa_pem(key: rsa.RSAPrivateKey) -> bytes:
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
 
 
 class GetPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
@@ -27,3 +46,68 @@ class GetPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
 
             mode = stat.S_IMODE(Path(path).stat().st_mode)
             self.assertEqual(mode, 0o600)
+
+    async def test_existing_key_read_path_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "private_key.pem")
+            creator = Tesla()
+            created = await creator.get_private_key(path)
+
+            reader = Tesla()
+            read_back = await reader.get_private_key(path)
+
+            self.assertEqual(_ec_pem(read_back), _ec_pem(created))
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+
+    async def test_concurrent_create_falls_back_to_read(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "private_key.pem")
+            winner = Tesla()
+            winner_key = await winner.get_private_key(path)
+
+            # Simulate a caller whose exists() check ran before the winner's
+            # create - it must fall back to reading the winner's file rather
+            # than raising FileExistsError.
+            loser = Tesla()
+            with mock.patch("tesla_fleet_api.tesla.tesla.exists", return_value=False):
+                key = await loser.get_private_key(path)
+
+            self.assertEqual(_ec_pem(key), _ec_pem(winner_key))
+
+
+class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
+    async def test_new_key_file_is_owner_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            tesla = Tesla()
+
+            await tesla.get_rsa_private_key(path, key_size=1024)
+
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+
+    async def test_existing_key_read_path_unchanged(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            creator = Tesla()
+            created = await creator.get_rsa_private_key(path, key_size=1024)
+
+            reader = Tesla()
+            read_back = await reader.get_rsa_private_key(path, key_size=1024)
+
+            self.assertEqual(_rsa_pem(read_back), _rsa_pem(created))
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+
+    async def test_concurrent_create_falls_back_to_read(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            winner = Tesla()
+            winner_key = await winner.get_rsa_private_key(path, key_size=1024)
+
+            loser = Tesla()
+            with mock.patch("tesla_fleet_api.tesla.tesla.exists", return_value=False):
+                key = await loser.get_rsa_private_key(path, key_size=1024)
+
+            self.assertEqual(_rsa_pem(key), _rsa_pem(winner_key))

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -145,6 +145,24 @@ class GetPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
 
             self.assertEqual(_ec_pem(key), _ec_pem(winner_key))
 
+    async def test_existing_path_waits_for_winner_to_finish_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "private_key.pem"
+            winner_key = ec.generate_private_key(ec.SECP256R1())
+            path.touch(mode=0o600)
+
+            async def finish_write() -> None:
+                await asyncio.sleep(0.1)
+                path.write_bytes(_ec_pem(winner_key))
+
+            writer = asyncio.create_task(finish_write())
+            try:
+                key = await Tesla().get_private_key(str(path))
+            finally:
+                await writer
+
+            self.assertEqual(_ec_pem(key), _ec_pem(winner_key))
+
 
 class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
     async def test_new_key_file_is_owner_only(self) -> None:
@@ -215,6 +233,27 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
                     "tesla_fleet_api.tesla.tesla.exists", return_value=False
                 ):
                     key = await loser.get_rsa_private_key(str(path), key_size=1024)
+            finally:
+                await writer
+
+            self.assertEqual(_rsa_pem(key), _rsa_pem(winner_key))
+
+    async def test_existing_path_waits_for_winner_to_finish_writing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = Path(tmp_dir) / "tedapi_rsa_private.pem"
+            winner_key = rsa.generate_private_key(
+                public_exponent=65537,
+                key_size=1024,
+            )
+            path.touch(mode=0o600)
+
+            async def finish_write() -> None:
+                await asyncio.sleep(0.1)
+                path.write_bytes(_rsa_pem(winner_key))
+
+            writer = asyncio.create_task(finish_write())
+            try:
+                key = await Tesla().get_rsa_private_key(str(path), key_size=1024)
             finally:
                 await writer
 

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -10,6 +10,7 @@ winner's file instead of raising.
 from __future__ import annotations
 
 import stat
+import os
 import tempfile
 from pathlib import Path
 from unittest import IsolatedAsyncioTestCase, mock
@@ -43,6 +44,19 @@ class GetPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             tesla = Tesla()
 
             await tesla.get_private_key(path)
+
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+
+    async def test_new_key_file_is_owner_only_with_restrictive_umask(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "private_key.pem")
+            tesla = Tesla()
+            old_umask = os.umask(0o777)
+            try:
+                await tesla.get_private_key(path)
+            finally:
+                os.umask(old_umask)
 
             mode = stat.S_IMODE(Path(path).stat().st_mode)
             self.assertEqual(mode, 0o600)
@@ -83,6 +97,19 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             tesla = Tesla()
 
             await tesla.get_rsa_private_key(path, key_size=1024)
+
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+
+    async def test_new_key_file_is_owner_only_with_restrictive_umask(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            tesla = Tesla()
+            old_umask = os.umask(0o777)
+            try:
+                await tesla.get_rsa_private_key(path, key_size=1024)
+            finally:
+                os.umask(old_umask)
 
             mode = stat.S_IMODE(Path(path).stat().st_mode)
             self.assertEqual(mode, 0o600)

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -38,6 +38,39 @@ def _rsa_pem(key: rsa.RSAPrivateKey) -> bytes:
 
 
 class GetPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
+    async def test_new_key_file_uses_chmod_without_fchmod(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "private_key.pem")
+
+            with (
+                mock.patch("tesla_fleet_api.tesla.tesla.os.fchmod", new=None),
+                mock.patch(
+                    "tesla_fleet_api.tesla.tesla.os.chmod", wraps=os.chmod
+                ) as chmod,
+            ):
+                await Tesla().get_private_key(path)
+
+            chmod.assert_called_once_with(path, 0o600)
+
+    async def test_new_key_file_closes_fd_when_chmod_fails(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "private_key.pem")
+
+            with (
+                mock.patch("tesla_fleet_api.tesla.tesla.os.fchmod", new=None),
+                mock.patch(
+                    "tesla_fleet_api.tesla.tesla.os.chmod",
+                    side_effect=OSError("chmod failed"),
+                ),
+                mock.patch(
+                    "tesla_fleet_api.tesla.tesla.os.close", wraps=os.close
+                ) as close,
+            ):
+                with self.assertRaises(OSError):
+                    await Tesla().get_private_key(path)
+
+            close.assert_called_once()
+
     async def test_new_key_file_is_owner_only(self) -> None:
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "private_key.pem")


### PR DESCRIPTION
## Intent

Harden private-key file creation so the PEM is born 0600 instead of written world-readable then chmod'd. get_private_key and get_rsa_private_key (tesla_fleet_api/tesla/tesla.py) previously wrote the PEM via aiofiles with the process default mode, then called chmod(path, 0o600) wrapped in except OSError: pass - leaving (a) a brief world-readable window on every fresh key and (b) a failed chmod silently leaving the key 0644 forever. Fix: both sites now create the file atomically with owner-only permissions via a custom aiofiles opener that calls os.open(path, O_WRONLY|O_CREAT|O_EXCL, 0o600) - no post-hoc chmod, no window, no swallowed failure. O_EXCL also closes the pre-existing TOCTOU race between the exists() check and the write: if a concurrent caller wins the create race (FileExistsError), the code deliberately falls back to reading that file instead of raising, matching the existing 'get or create' contract of these methods. This is a narrowly scoped security-hardening fix - no other behavior of get_private_key/get_rsa_private_key was changed (encoding, format, encryption_algorithm, and the load/read path for pre-existing keys are all unchanged). Added 6 new/updated tests in tests/test_tesla_private_key.py covering: fresh key file is 0600 immediately after creation (for both the EC and RSA key), existing-key read path is unchanged, and the concurrent-create race falls back to a read instead of raising (simulated by mocking exists() to return False while the target file already exists). This is a companion PR to a sibling fix (_log_request_result None-guard) on a different branch; both are intended to ship together in release 1.7.2, but this PR stands alone and does not depend on the other.

## What Changed
- Hardened EC and RSA private-key creation so new PEM files are opened atomically with owner-only permissions instead of being written first and chmodded afterward.
- Added bounded retries for raced reads so concurrent callers can load the winning key once the creator finishes writing it.
- Documented the `0600` private-key file requirement across the README and related docs, and expanded private-key tests around permissions and creation races.

## Risk Assessment

✅ Low: The change is narrowly scoped to private-key file creation and raced reads, with the previously identified permission, portability, and partial-read concerns now addressed and covered by focused tests.

## Testing

Exercised the key creation/read/race paths directly through `Tesla.get_private_key` and `Tesla.get_rsa_private_key`, captured mode/key-material evidence under `/tmp/no-mistakes-evidence`, then ran the focused private-key tests and the full test suite; all passed and the worktree remained clean.

<details>
<summary>Evidence: API-level private-key permission evidence</summary>

```text
{
  "checks": [
    {
      "api": "Tesla.get_private_key",
      "operation": "fresh create",
      "path": "/tmp/tmpzbdjsgu3/private_key.pem",
      "mode": "0o600",
      "pem_header": "-----BEGIN EC PRIVATE KEY-----"
    },
    {
      "api": "Tesla.get_private_key",
      "operation": "existing read",
      "same_key_material": true,
      "mode_after_read": "0o600"
    },
    {
      "api": "Tesla.get_rsa_private_key",
      "operation": "fresh create",
      "path": "/tmp/tmpzbdjsgu3/tedapi_rsa_private.pem",
      "mode": "0o600",
      "pem_header": "-----BEGIN RSA PRIVATE KEY-----"
    },
    {
      "api": "Tesla.get_rsa_private_key",
      "operation": "existing read",
      "same_key_material": true,
      "mode_after_read": "0o600"
    },
    {
      "api": "Tesla.get_private_key",
      "operation": "simulated concurrent create loser fallback",
      "same_key_material": true,
      "mode_after_race": "0o600"
    },
    {
      "api": "Tesla.get_rsa_private_key",
      "operation": "simulated concurrent create loser fallback",
      "same_key_material": true,
      "mode_after_race": "0o600"
    }
  ],
  "result": "all API-level private key checks passed"
}
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (4) ✅</summary>

- ⚠️ `tesla_fleet_api/tesla/tesla.py:22` - `os.open(..., 0o600)` is still filtered by the process umask, so a restrictive umask can create the key as `0400` or even `0000` instead of the previous final `0600`. That can make a freshly created key unreadable on the next process run and breaks the documented exact-permission contract; create the fd with owner-only bits, then `fchmod(fd, 0o600)` before returning it so there is still no wider-permission window.

🔧 Fix: Force key permissions after atomic create
1 warning still open:
- ⚠️ `tesla_fleet_api/tesla/tesla.py:24` - Fresh key creation now calls `os.fchmod()` unconditionally, but this package is advertised as OS-independent and `os.fchmod` is Unix-only. On Windows this raises after `os.open()` has already created the file, leaks the fd, and leaves an empty PEM path that later reads fail to deserialize; guard the fd chmod with a portable fallback such as `hasattr(os, &#34;fchmod&#34;)` plus path chmod where needed.

🔧 Fix: Make key opener portable without fchmod
1 warning still open:
- ⚠️ `tesla_fleet_api/tesla/tesla.py:71` - The `FileExistsError` fallback can still lose the real concurrent-create race: the winning process creates the file before it writes and closes the PEM, so a loser can hit this branch, immediately read an empty or partial file, and raise deserialization errors instead of satisfying the get-or-create contract. On this raced path, retry the read/deserialize for a short bounded window or otherwise wait until the creator has finished writing before loading the key.

🔧 Fix: Retry raced private-key reads
1 warning still open:
- ⚠️ `tesla_fleet_api/tesla/tesla.py:100` - A concurrent caller can still read the file while the winner has created it but before the PEM write has completed: in that timing `exists(path)` is already true, so this normal read path calls `_load_pem_private_key(path)` without `retry_invalid=True` and can raise a deserialization `ValueError` instead of satisfying the get-or-create contract. Apply the same bounded partial-write retry on the existing-file read path, or otherwise publish completed PEM contents atomically.

🔧 Fix: Retry existing key reads during creation race
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `uv run pytest tests/test_tesla_private_key.py`
- `uv run python - <<'PY' > /tmp/no-mistakes-evidence/01KXAXPMK9CVW1QA0YKFJNAG0F/private_key_atomic_0600_evidence.json ...`
- `uv run pytest tests`
- `git status --short`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
