### PR TITLE
chore: bump version to 1.7.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.7.1"
+version = "1.7.2"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api.egg-info/PKG-INFO
+++ b/tesla_fleet_api.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: tesla_fleet_api
-Version: 1.7.1
+Version: 1.7.2
 Summary: Tesla Fleet API library for Python
 Author-email: Brett Adams <hello@teslemetry.com>
 License-Expression: Apache-2.0

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.7.1"
+__version__ = "1.7.2"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.tesla.bluetooth import TeslaBluetooth

--- a/uv.lock
+++ b/uv.lock
@@ -728,7 +728,7 @@ wheels = [
 
 [[package]]
 name = "tesla-fleet-api"
-version = "1.7.1"
+version = "1.7.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Intent

Cut python-tesla-fleet-api release 1.7.2. This is a pure version-bump release train: both constituent PRs (#73 fix(fleet): handle non-object JSON command logging - fixes a prod Powerwall-500 regression where TeslemetryEnergySite calls that return null/list/scalar JSON bodies crashed _log_request_result's logging convenience code; and #74 fix(tesla): create private keys atomically with owner-only permissions via O_EXCL 0600) are already merged to main. The only change in this PR is bumping version from 1.7.1 to 1.7.2 in pyproject.toml and tesla_fleet_api/__init__.py, following the exact same mechanics as the 1.7.0 and 1.7.1 version-bump cuts (see PRs #69 and #71 in this repo's history). No functional code changes, no new features - just the release version bump commit. uv.lock is expected to also get its tesla-fleet-api version entry updated (either by me or by the no-mistakes document/lint step, matching how the 1.7.1 bump PR handled it).

## What Changed

- Bump the package release version from `1.7.1` to `1.7.2` in `pyproject.toml` and `tesla_fleet_api/__init__.py`.
- Sync tracked release metadata in `uv.lock` and `tesla_fleet_api.egg-info/PKG-INFO` so all packaged version references agree.

## Risk Assessment

✅ Low: The reviewed delta is limited to internally consistent 1.7.1 to 1.7.2 release metadata updates across pyproject, package __version__, uv.lock, and tracked egg-info, with no functional code changes.

## Testing

Diff inspection confirmed the release bump surfaces moved to 1.7.2, `uv build` produced wheel and sdist artifacts named and stamped 1.7.2, archive inspection confirmed wheel metadata, sdist metadata, and package `__version__` agree, and `uv run pytest tests` passed.

<details>
<summary>Evidence: Release version evidence</summary>

<code>Built artifacts:&#10;tesla_fleet_api-1.7.2-py3-none-any.whl&#10;tesla_fleet_api-1.7.2.tar.gz&#10;&#10;Wheel METADATA version:&#10;Metadata-Version: 2.4&#10;Name: tesla_fleet_api&#10;Version: 1.7.2&#10;&#10;Wheel package __version__ line:&#10;__version__ = &#34;1.7.2&#34;&#10;&#10;Sdist PKG-INFO version:&#10;Metadata-Version: 2.4&#10;Name: tesla_fleet_api&#10;Version: 1.7.2</code>

```text
Built artifacts:
tesla_fleet_api-1.7.2-py3-none-any.whl
tesla_fleet_api-1.7.2.tar.gz

Wheel METADATA version:
Metadata-Version: 2.4
Name: tesla_fleet_api
Version: 1.7.2
Summary: Tesla Fleet API library for Python
Author-email: Brett Adams <hello@teslemetry.com>
License-Expression: Apache-2.0

Wheel package __version__ line:
"""Tesla Fleet API"""

__author__ = "hello@teslemetry.com"
__version__ = "1.7.2"


Sdist PKG-INFO version:
Metadata-Version: 2.4
Name: tesla_fleet_api
Version: 1.7.2
Summary: Tesla Fleet API library for Python
Author-email: Brett Adams <hello@teslemetry.com>
License-Expression: Apache-2.0
```
</details>
- Evidence: Built wheel (local file: <code>/tmp/no-mistakes-evidence/01KXAZV7EAQAJ4C4RY9HTCFTY1/dist/tesla_fleet_api-1.7.2-py3-none-any.whl</code>)
- Evidence: Built sdist (local file: <code>/tmp/no-mistakes-evidence/01KXAZV7EAQAJ4C4RY9HTCFTY1/dist/tesla_fleet_api-1.7.2.tar.gz</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed (2) ✅</summary>

- ⚠️ `pyproject.toml:7` - The release metadata now says 1.7.2, but the checked-in `uv.lock` still records the editable `tesla-fleet-api` package as 1.7.1. Update/regenerate the lockfile so the release bump is internally consistent.

🔧 Fix: Sync release lockfile version
1 warning still open:
- ⚠️ `tesla_fleet_api.egg-info/PKG-INFO:3` - The tracked egg-info metadata still reports Version: 1.7.1 while the package/version constants were bumped to 1.7.2. Because this file is tracked and was consistent at the base commit, the release bump now leaves repository metadata internally inconsistent; regenerate or update the egg-info metadata for the release.

🔧 Fix: Sync egg-info release version
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --unified=3 c618141495b61eab18f40033fd6fef66a82a0a9c..684e6c0c2c583bded3cc08dde107201139b08bcb -- pyproject.toml tesla_fleet_api/__init__.py uv.lock tesla_fleet_api.egg-info/PKG-INFO`
- `rg -n "1\.7\.[0-9]|version =|__version__|Version:" pyproject.toml tesla_fleet_api/__init__.py uv.lock tesla_fleet_api.egg-info/PKG-INFO`
- `uv build --out-dir /tmp/no-mistakes-evidence/01KXAZV7EAQAJ4C4RY9HTCFTY1/dist`
- `uv run pytest tests`
- <code>`unzip`/`tar` inspection recorded in `/tmp/no-mistakes-evidence/01KXAZV7EAQAJ4C4RY9HTCFTY1/release-version-evidence.txt`</code>
- <code>Cleanup/status check: removed transient `.venv`, restored build-regenerated `tesla_fleet_api.egg-info/PKG-INFO`, and confirmed no worktree test artifacts remained</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
