### PR TITLE
chore: bump version to 1.7.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.7.2"
+version = "1.7.3"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api.egg-info/PKG-INFO
+++ b/tesla_fleet_api.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 2.4
 Name: tesla_fleet_api
-Version: 1.7.2
+Version: 1.7.3
 Summary: Tesla Fleet API library for Python
 Author-email: Brett Adams <hello@teslemetry.com>
 License-Expression: Apache-2.0

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.7.2"
+__version__ = "1.7.3"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.tesla.bluetooth import TeslaBluetooth

--- a/uv.lock
+++ b/uv.lock
@@ -728,7 +728,7 @@ wheels = [
 
 [[package]]
 name = "tesla-fleet-api"
-version = "1.7.2"
+version = "1.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Intent

Cut python-tesla-fleet-api release 1.7.3 - pure release-mechanics task, no code changes. Bump version from 1.7.2 to 1.7.3 in pyproject.toml and tesla_fleet_api/__init__.py, mirroring the exact shape of the 1.7.1 (#71) and 1.7.2 (#75) bump commits (chore: bump version to X.Y.Z, plain string replace, no other files touched by hand - uv.lock and egg-info/PKG-INFO are synced by the no-mistakes pipeline itself as it did in those prior runs). This release's headline content is everything already merged to main since v1.7.2: the typed find_authorized_clients accessor (PR #76, feat(teslemetry): add typed authorized clients accessor) and the BLE broadcast listeners feature (PR #72). Scope is deliberately narrow: do not fold in any other library change, do not touch CHANGELOG.md (auto-generated), and do not pin/change the authorized_clients wire shape - that accessor already shipped merged and evidence-bounded. This task stops after PR merge; pushing the vX.Y.Z release tag (which triggers the actual PyPI publish via python-publish.yml) is an explicit separate follow-up task, not part of this one.

## What Changed

- Bumped the package release version from `1.7.2` to `1.7.3` in `pyproject.toml` and `tesla_fleet_api/__init__.py`.
- Synced checked-in release metadata in `uv.lock` and `tesla_fleet_api.egg-info/PKG-INFO` so all package version references agree on `1.7.3`.
- Validation passed through the no-mistakes pipeline, including tests, lint, wheel build/install checks, and sdist verification.

## Risk Assessment

✅ Low: The change is a narrow release metadata bump, and all tracked version markers now consistently read 1.7.3 with no code or dependency behavior changes.

## Testing

Checked the release-bump diff, ran the full pytest suite, built wheel and sdist artifacts, installed the wheel into an isolated evidence venv, and captured JSON evidence showing package metadata and import-time version resolve to 1.7.3; all validation passed and the worktree was cleaned afterward.

<details>
<summary>Evidence: Installed wheel version evidence</summary>

```text
{
  "imported_module_file": "/tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/package-check-venv/lib/python3.14/site-packages/tesla_fleet_api/__init__.py",
  "imported_module_version": "1.7.3",
  "installed_distribution_name": "tesla_fleet_api",
  "installed_distribution_version": "1.7.3",
  "wheel": "/tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/dist/tesla_fleet_api-1.7.3-py3-none-any.whl",
  "wheel_exists": true,
  "wheel_metadata_name": "tesla_fleet_api",
  "wheel_metadata_version": "1.7.3"
}
```
</details>
<details>
<summary>Evidence: Source distribution version evidence</summary>

```text
{
  "contains_authorized_clients_test": true,
  "contains_broadcast_module": true,
  "sdist": "/tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/dist/tesla_fleet_api-1.7.3.tar.gz",
  "sdist_exists": true,
  "sdist_metadata_name": "tesla_fleet_api",
  "sdist_metadata_version": "1.7.3"
}
```
</details>
- Evidence: Built wheel (local file: <code>/tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/dist/tesla_fleet_api-1.7.3-py3-none-any.whl</code>)
- Evidence: Built source tarball (local file: <code>/tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/dist/tesla_fleet_api-1.7.3.tar.gz</code>)

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 1 issue found → auto-fixed ✅</summary>

- 🚨 `pyproject.toml:7` - Bumping the project version here leaves the checked-in release metadata stale: `uv.lock` still has the editable package at `1.7.2`, and `tesla_fleet_api.egg-info/PKG-INFO` still says `Version: 1.7.2`. The prior 1.7.1/1.7.2 release bumps synced these files in the same PR, so merging this as-is leaves the repository with conflicting package versions for the 1.7.3 release. Update the lockfile and egg-info metadata to `1.7.3` in the release branch.

🔧 Fix: Sync release metadata to 1.7.3
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff --stat 02834599a16d404819c20d95712cc5793060948e..c8554c1dca8c9a54cad26946f5b1656f90866a20`
- `git diff 02834599a16d404819c20d95712cc5793060948e..c8554c1dca8c9a54cad26946f5b1656f90866a20 -- pyproject.toml tesla_fleet_api/__init__.py uv.lock tesla_fleet_api.egg-info/PKG-INFO`
- `uv run pytest tests`
- `uv build --wheel --out-dir /tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/dist`
- `uv venv /tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/package-check-venv && uv pip install --python /tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/package-check-venv/bin/python /tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/dist/tesla_fleet_api-1.7.3-py3-none-any.whl`
- `/tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/package-check-venv/bin/python ... > /tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/release-1.7.3-package-evidence.json`
- `uv build --sdist --out-dir /tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/dist`
- `/tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/package-check-venv/bin/python ... > /tmp/no-mistakes-evidence/01KXC9K2CMDJ8VZSMVW9S331EX/release-1.7.3-sdist-evidence.json`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
