### PR TITLE
docs(teslemetry): correct find_authorized_clients reliability claim

### DIFF
--- a/docs/teslemetry.md
+++ b/docs/teslemetry.md
@@ -558,10 +558,10 @@ never mistaken for "no authorized clients". `state` is typed as
 `AuthorizedClientState`. The raw response is still available on `raw` for
 anything not modeled.
 
-Use these cloud helpers only as secondary, best-effort checks during local key
-pairing. They are not authoritative verification that a key can make signed
-LAN requests; the reliable proof is a successful signed local read through the
-paired client, as shown in [Energy: Local Control](energy_local_control.md).
+These cloud helpers report the gateway's registered-client state as returned
+by the Teslemetry API. Confirming that a key can actually make signed LAN
+requests requires a successful signed local read through the paired client,
+as shown in [Energy: Local Control](energy_local_control.md).
 
 ```python
 async def main():

--- a/tesla_fleet_api/teslemetry/energysite.py
+++ b/tesla_fleet_api/teslemetry/energysite.py
@@ -324,11 +324,8 @@ class TeslemetryEnergySite(EnergySite):
         caller. Raises
         :class:`~tesla_fleet_api.exceptions.InvalidResponse` on a null
         response body or an unrecognized response shape rather than
-        treating either as "no clients". Treat it as a secondary,
-        best-effort cloud check during local key pairing; a successful
-        signed local read through the paired LAN client is the
-        authoritative verification. See :class:`AuthorizedClients` for the
-        exact parsing semantics.
+        treating either as "no clients". See :class:`AuthorizedClients` for
+        the exact parsing semantics.
         """
         return _parse_authorized_clients(await self.list_authorized_clients())
 


### PR DESCRIPTION
## Intent
- `find_authorized_clients()`'s docstring (and the matching passage in `docs/teslemetry.md`) described the cloud authorized-clients check as "best-effort" with an implied staleness/malformed-data concern
  - Traced the claim via git history: the one confirmed anomaly is an intermittent null response body, already root-caused and attributed to the Teslemetry API response itself (`f801be1`/`f65ceb5`), not the underlying Tesla command - and it's already handled by raising `InvalidResponse` with test coverage
  - No repo evidence supports a broader staleness/reliability claim about the command
- Rewrote both spots to state what the accessor returns/raises factually, dropping the unevidenced reliability editorializing (without swinging to overpromising reliability either)
- `docs/energy_local_control.md` and `AGENTS.md` were left as-is - their wording around the null-body issue is already correctly scoped to the Teslemetry response and evidenced, so nothing there needed correcting

## Pipeline
Skipped per standing rule for docs-only changes in this repo - no behavior change, docstring/docs wording only. Ran locally instead: `uv run pytest tests` (362 passed), `uv run ruff check`, `uv run pyright` (all clean).
