### PR TITLE
Bump version to 1.7.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.7.5"
+version = "1.7.6"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.7.5"
+__version__ = "1.7.6"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.tesla.bluetooth import TeslaBluetooth


### PR DESCRIPTION
## Intent
- Bump `version`/`__version__` from 1.7.5 to 1.7.6 to release the three unreleased commits on `main`
- No behavior changes in this PR itself; pushing the `v1.7.6` tag afterward is what publishes to PyPI (`.github/workflows/python-publish.yml` fires on tag push, not on merge)

## Changes going into 1.7.6
- fix(vehicle): align `navigation_gps_request` `order` default across transports (#83)
- fix(energy): raise `SignedCommandRequired` from cloud-only island mode commands (#84)
- docs(teslemetry): correct `find_authorized_clients` reliability claim (#82)

## Semver note for review
- #84 changes `set_island_mode`/`go_off_grid`/`reconnect_grid` from a silent unsigned no-op to unconditionally raising `SignedCommandRequired` - a behavior change for any caller not on the signed local path. Treated as patch here since the prior no-op never actually actuated the contactor, but flagging in case a minor (1.8.0) is preferred instead.
