### PR TITLE
style: fix pre-existing ruff format drift

### DIFF
--- a/tesla_fleet_api/tesla/bluetooth.py
+++ b/tesla_fleet_api/tesla/bluetooth.py
@@ -15,6 +15,7 @@ from tesla_fleet_api.tesla.tesla import Tesla
 from tesla_fleet_api.tesla.vehicle.bluetooth import NAME_UUID
 from tesla_fleet_api.tesla.vehicle.vehicles import VehiclesBluetooth
 
+
 class TeslaBluetooth(Tesla):
     """Class describing a Tesla Bluetooth connection."""
 
@@ -33,26 +34,27 @@ class TeslaBluetooth(Tesla):
 
     def get_name(self, vin: str) -> str:
         """Get the name of a vehicle."""
-        return "S" + hashlib.sha1(vin.encode('utf-8')).hexdigest()[:16] + "C"
+        return "S" + hashlib.sha1(vin.encode("utf-8")).hexdigest()[:16] + "C"
 
-    async def query_display_name(self, device: BLEDevice, max_attempts: int = 5) -> str | None:
+    async def query_display_name(
+        self, device: BLEDevice, max_attempts: int = 5
+    ) -> str | None:
         """Queries the name of a bluetooth vehicle."""
         client = await establish_connection(
-            BleakClient,
-            device,
-            device.name or "Unknown",
-            max_attempts=max_attempts
+            BleakClient, device, device.name or "Unknown", max_attempts=max_attempts
         )
         name: str | None = None
         for i in range(max_attempts):
             try:
                 # Standard GATT Device Name characteristic (0x2A00)
-                device_name = (await client.read_gatt_char(NAME_UUID)).decode('utf-8')
+                device_name = (await client.read_gatt_char(NAME_UUID)).decode("utf-8")
                 if device_name.startswith("🔑 "):
-                    name = device_name.replace("🔑 ","")
+                    name = device_name.replace("🔑 ", "")
                     break
                 await asyncio.sleep(1)
-                LOGGER.debug(f"Attempt {i+1} to query display name failed, {device_name}")
+                LOGGER.debug(
+                    f"Attempt {i + 1} to query display name failed, {device_name}"
+                )
             except Exception as e:
                 LOGGER.error(f"Failed to read device name: {e}")
 
@@ -62,9 +64,11 @@ class TeslaBluetooth(Tesla):
 
 # Helpers
 
+
 def toJson(message: Message) -> str:
     """Convert a protobuf message to JSON."""
     return MessageToJson(message, preserving_proto_field_name=True)
+
 
 def toDict(message: Message) -> dict[str, Any]:
     """Convert a protobuf message to a dictionary."""

--- a/tesla_fleet_api/tesla/vehicle/vehicle.py
+++ b/tesla_fleet_api/tesla/vehicle/vehicle.py
@@ -17,6 +17,7 @@ MODELS = {
     "T": "Semi",
 }
 
+
 class Vehicle(Generic[ParentT]):
     """Base class describing a Tesla vehicle."""
 
@@ -30,7 +31,10 @@ class Vehicle(Generic[ParentT]):
     @property
     def pre2021(self) -> bool:
         """Checks if a vehicle is a pre-2021 model S or X."""
-        return self.vin[3] in ["S", "X"] and (self.vin[9] <= "L" or (self.vin[9] == "M" and self.vin[7] in ['1', '2', '3', '4']))
+        return self.vin[3] in ["S", "X"] and (
+            self.vin[9] <= "L"
+            or (self.vin[9] == "M" and self.vin[7] in ["1", "2", "3", "4"])
+        )
 
     @property
     def model(self) -> str:

--- a/tesla_fleet_api/tessie/__init__.py
+++ b/tesla_fleet_api/tessie/__init__.py
@@ -2,7 +2,10 @@ from tesla_fleet_api.tessie.tessie import Tessie
 from tesla_fleet_api.tesla.charging import Charging
 from tesla_fleet_api.tesla.energysite import EnergySites, EnergySite
 from tesla_fleet_api.tesla.user import User
-from tesla_fleet_api.tessie.vehicle import TessieVehicles as Vehicles, TessieVehicle as Vehicle
+from tesla_fleet_api.tessie.vehicle import (
+    TessieVehicles as Vehicles,
+    TessieVehicle as Vehicle,
+)
 
 __all__ = [
     "Tessie",


### PR DESCRIPTION
Pre-existing `ruff format` drift on `main` in three files, unrelated to any feature work — fixing it so `main` is green and a parked PR (proto-mirror) can rebase cleanly.

- `tesla_fleet_api/tesla/bluetooth.py`
- `tesla_fleet_api/tesla/vehicle/vehicle.py`
- `tesla_fleet_api/tessie/__init__.py`

Formatting only (`uv run ruff format` output), no logic changes. `uv run ruff check` and the test suite (371 passed) are unaffected.

Note: `keytool.py` and `tests/test_tessie_vehicle_params.py` also fail `ruff format --check` on `main` but are left out of this PR to keep it scoped to a single concern.