### PR TITLE
fix(tesla): prevent RSA key generation from blocking asyncio

### DIFF
--- a/docs/energy_local_control.md
+++ b/docs/energy_local_control.md
@@ -26,6 +26,13 @@ inherits it - `TeslaFleetApi`, `Teslemetry`, `Tessie`) loads an existing RSA
 private key or creates a new 4096-bit unencrypted PEM key file. This is the
 key you will register with the gateway and later hand to `aiopowerwall`.
 
+Creating a new key uses a worker process so RSA generation does not block the
+asyncio event loop. Call it from a script or module with a spawn-safe entry
+point (guard application startup with `if __name__ == "__main__":`). Key
+generation is not supported directly from a REPL, `python -c`, or a notebook
+cell; loading an existing key file does not start a worker process and works in
+those environments.
+
 ## 2. Register the key with the gateway, over the cloud
 
 `EnergySite.add_authorized_client` registers the public half of that key with

--- a/docs/energy_local_control.md
+++ b/docs/energy_local_control.md
@@ -26,13 +26,13 @@ inherits it - `TeslaFleetApi`, `Teslemetry`, `Tessie`) loads an existing RSA
 private key or creates a new 4096-bit unencrypted PEM key file. This is the
 key you will register with the gateway and later hand to `aiopowerwall`.
 
-Creating a new key uses a worker process so RSA generation does not block the
-asyncio event loop. Call it from a script or module with a spawn-safe entry
-point (guard application startup with `if __name__ == "__main__":`) when
-possible. If the worker process cannot start, including from a REPL,
-`python -c`, or a notebook cell, generation falls back to the current process
-and logs a warning that the asyncio event loop may be blocked. Loading an
-existing key file does not start a worker process.
+Creating a new key uses a plain `sys.executable -c` subprocess so RSA generation
+does not block the asyncio event loop. The subprocess runs its own script as
+`__main__` and never imports the caller's entry point, so this works from
+scripts, REPLs, `python -c`, and notebooks without an entry-point guard. If the
+subprocess cannot start or exits unsuccessfully, generation falls back to the
+current process and logs a warning that the asyncio event loop may be blocked.
+Loading an existing key file does not start a subprocess.
 
 ## 2. Register the key with the gateway, over the cloud
 

--- a/docs/energy_local_control.md
+++ b/docs/energy_local_control.md
@@ -28,10 +28,11 @@ key you will register with the gateway and later hand to `aiopowerwall`.
 
 Creating a new key uses a worker process so RSA generation does not block the
 asyncio event loop. Call it from a script or module with a spawn-safe entry
-point (guard application startup with `if __name__ == "__main__":`). Key
-generation is not supported directly from a REPL, `python -c`, or a notebook
-cell; loading an existing key file does not start a worker process and works in
-those environments.
+point (guard application startup with `if __name__ == "__main__":`) when
+possible. If the worker process cannot start, including from a REPL,
+`python -c`, or a notebook cell, generation falls back to the current process
+and logs a warning that the asyncio event loop may be blocked. Loading an
+existing key file does not start a worker process.
 
 ## 2. Register the key with the gateway, over the cloud
 

--- a/docs/energy_local_control.md
+++ b/docs/energy_local_control.md
@@ -30,9 +30,10 @@ Creating a new key uses a plain `sys.executable -c` subprocess so RSA generation
 does not block the asyncio event loop. The subprocess runs its own script as
 `__main__` and never imports the caller's entry point, so this works from
 scripts, REPLs, `python -c`, and notebooks without an entry-point guard. If the
-subprocess cannot start or exits unsuccessfully, generation falls back to the
-current process and logs a warning that the asyncio event loop may be blocked.
-Loading an existing key file does not start a subprocess.
+subprocess cannot be used (including in a frozen application), exits
+unsuccessfully, or returns empty or invalid key data, generation falls back to
+the current process and logs a warning that the asyncio event loop may be
+blocked. Loading an existing key file does not start a subprocess.
 
 ## 2. Register the key with the gateway, over the cloud
 

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -153,7 +153,8 @@ class Tesla:
         the create race, its file is read instead of raising.
         """
         if not exists(path):
-            self.rsa_private_key = rsa.generate_private_key(
+            self.rsa_private_key = await asyncio.to_thread(
+                rsa.generate_private_key,
                 public_exponent=65537,
                 key_size=key_size,
                 backend=default_backend(),

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -2,6 +2,7 @@
 
 import base64
 import asyncio
+from contextlib import suppress
 import os
 import sys
 import time
@@ -86,7 +87,8 @@ async def _generate_rsa_private_key_pem_isolated(key_size: int) -> bytes:
     try:
         stdout, stderr = await proc.communicate()
     except asyncio.CancelledError:
-        proc.kill()
+        with suppress(ProcessLookupError):
+            proc.kill()
         await proc.wait()
         raise
     if proc.returncode != 0:

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -5,6 +5,7 @@ import asyncio
 import os
 import time
 from concurrent.futures import ProcessPoolExecutor
+from concurrent.futures.process import BrokenProcessPool
 from multiprocessing import get_context
 from os.path import exists
 import aiofiles
@@ -22,13 +23,15 @@ from cryptography.hazmat.backends import default_backend
 
 _KEY_READ_RETRY_TIMEOUT = 1.0
 _KEY_READ_RETRY_INTERVAL = 0.05
-_RSA_KEY_GENERATION_EXECUTOR = ProcessPoolExecutor(
-    max_workers=1, mp_context=get_context("spawn")
-)
 
 
 def _generate_rsa_private_key_pem(key_size: int) -> bytes:
-    """Generate an RSA key outside the main process and return serialized material."""
+    """Generate an RSA key and serialize it, for use in a worker process.
+
+    cryptography's RSA keygen holds the GIL for its full duration, so a
+    thread (unlike a separate process) would still stall the caller's event
+    loop.
+    """
     key = rsa.generate_private_key(
         public_exponent=65537,
         key_size=key_size,
@@ -39,6 +42,38 @@ def _generate_rsa_private_key_pem(key_size: int) -> bytes:
         format=serialization.PrivateFormat.TraditionalOpenSSL,
         encryption_algorithm=serialization.NoEncryption(),
     )
+
+
+async def _generate_rsa_private_key(key_size: int) -> tuple[rsa.RSAPrivateKey, bytes]:
+    """Generate an RSA key in a short-lived worker process and return it with its PEM.
+
+    The pool is created fresh per call (not at import time) so importing this
+    module never requires a spawn-safe entry point; only actually generating a
+    key does. `spawn` needs to re-import `__main__`, which fails under a REPL,
+    `python -c`, or a notebook cell - surfaced here as a clear error instead of
+    an opaque BrokenProcessPool.
+    """
+    with ProcessPoolExecutor(max_workers=1, mp_context=get_context("spawn")) as pool:
+        try:
+            pem = await asyncio.get_running_loop().run_in_executor(
+                pool, _generate_rsa_private_key_pem, key_size
+            )
+        except BrokenProcessPool as err:
+            raise RuntimeError(
+                "RSA key generation requires a subprocess-spawnable entry "
+                "point (a script or module guarded by "
+                "`if __name__ == '__main__':`); it cannot run from a REPL, "
+                "`python -c`, or a notebook cell."
+            ) from err
+    value = await asyncio.to_thread(
+        serialization.load_pem_private_key,
+        pem,
+        password=None,
+        backend=default_backend(),
+    )
+    if not isinstance(value, rsa.RSAPrivateKey):
+        raise AssertionError("Generated key is not an RSAPrivateKey")
+    return value, pem
 
 
 def _owner_only_opener(file: str, flags: int) -> int:
@@ -172,16 +207,7 @@ class Tesla:
         the create race, its file is read instead of raising.
         """
         if not exists(path):
-            pem = await asyncio.get_running_loop().run_in_executor(
-                _RSA_KEY_GENERATION_EXECUTOR,
-                _generate_rsa_private_key_pem,
-                key_size,
-            )
-            value = serialization.load_pem_private_key(
-                pem, password=None, backend=default_backend()
-            )
-            if not isinstance(value, rsa.RSAPrivateKey):
-                raise AssertionError("Generated key is not an RSAPrivateKey")
+            value, pem = await _generate_rsa_private_key(key_size)
             self.rsa_private_key = value
             try:
                 async with aiofiles.open(

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -3,9 +3,8 @@
 import base64
 import asyncio
 import os
+import sys
 import time
-from concurrent.futures import ProcessPoolExecutor
-from multiprocessing import get_context
 from os.path import exists
 import aiofiles
 
@@ -26,11 +25,12 @@ _KEY_READ_RETRY_INTERVAL = 0.05
 
 
 def _generate_rsa_private_key_pem(key_size: int) -> bytes:
-    """Generate an RSA key and serialize it, for use in a worker process.
+    """Generate an RSA key and serialize it.
 
     cryptography's RSA keygen holds the GIL for its full duration, so a
     thread (unlike a separate process) would still stall the caller's event
-    loop.
+    loop; used both as the isolated subprocess's script body and as the
+    in-process fallback.
     """
     key = rsa.generate_private_key(
         public_exponent=65537,
@@ -44,46 +44,77 @@ def _generate_rsa_private_key_pem(key_size: int) -> bytes:
     )
 
 
-async def _generate_rsa_private_key_pem_isolated(key_size: int) -> bytes:
-    """Generate an RSA key's PEM in a short-lived worker process.
+_RSA_KEYGEN_SUBPROCESS_SCRIPT = """
+import sys
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
-    The pool is created fresh per call (not at import time) so importing this
-    module never requires a spawn-safe entry point; only actually generating a
-    key does. Process isolation is best-effort: pool creation or submission
-    can fail in ways this function does not attempt to enumerate - a
-    restrictive umask blocking the pool's own semaphore file,
-    `spawn` unable to re-import `__main__` from a REPL/`python -c`/notebook,
-    `AssertionError` from an already-daemonic calling process, or any other
-    environment that can't host a worker process - so the caller catches
-    broadly and falls back to in-process generation.
+key = rsa.generate_private_key(
+    public_exponent=65537, key_size=int(sys.argv[1]), backend=default_backend()
+)
+sys.stdout.buffer.write(
+    key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+)
+"""
+
+
+async def _generate_rsa_private_key_pem_isolated(key_size: int) -> bytes:
+    """Generate an RSA key's PEM in a plain, short-lived `sys.executable -c ...` subprocess.
+
+    Unlike `multiprocessing`, a plain subprocess's `-c` script is its own
+    `__main__` - it never re-imports the caller's actual entry point, so
+    there is nothing to guard, nothing to pickle, no semaphore to create, and
+    no daemonic-process restriction. `asyncio.create_subprocess_exec` is
+    awaited natively, off the loop by construction, including cancellation:
+    killing and awaiting the child's exit are both async, so cancelling the
+    caller can't block the loop either. Raises on any exec or non-zero-exit
+    failure, so the caller can fall back to in-process generation.
     """
-    pool = ProcessPoolExecutor(max_workers=1, mp_context=get_context("spawn"))
+    proc = await asyncio.create_subprocess_exec(
+        sys.executable,
+        "-c",
+        _RSA_KEYGEN_SUBPROCESS_SCRIPT,
+        str(key_size),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
     try:
-        return await asyncio.get_running_loop().run_in_executor(
-            pool, _generate_rsa_private_key_pem, key_size
+        stdout, stderr = await proc.communicate()
+    except asyncio.CancelledError:
+        proc.kill()
+        await proc.wait()
+        raise
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"RSA key generation subprocess exited with code {proc.returncode}: "
+            f"{stderr.decode(errors='replace').strip()}"
         )
-    finally:
-        await asyncio.to_thread(pool.shutdown, wait=True, cancel_futures=True)
+    return stdout
 
 
 async def _generate_rsa_private_key(key_size: int) -> tuple[rsa.RSAPrivateKey, bytes]:
     """Generate an RSA key and return it with its PEM.
 
-    Prefers a short-lived worker process so keygen - which holds the GIL for
-    its full duration, unlike a thread - never stalls the caller's event
-    loop. Falls back to in-process generation, which does block the loop,
-    whenever that worker process can't be used - the same environments this
-    method could already generate keys in before process isolation was
-    introduced. The fallback catches any exception from pool creation or
-    submission, deliberately not enumerated by type, since process isolation
-    is best-effort here and any way it can fail should degrade to the
-    working (if blocking) legacy path rather than propagate.
+    Prefers a short-lived subprocess so keygen - which holds the GIL for its
+    full duration, unlike a thread - never stalls the caller's event loop.
+    Falls back to in-process generation, which does block the loop, whenever
+    that subprocess can't be used - the same environments this method could
+    already generate keys in before process isolation was introduced. The
+    fallback catches any exception from launching or running the subprocess,
+    deliberately not enumerated by type, since process isolation is
+    best-effort here and any way it can fail should degrade to the working
+    (if blocking) legacy path rather than propagate.
     """
     try:
         pem = await _generate_rsa_private_key_pem_isolated(key_size)
     except Exception as err:
         LOGGER.warning(
-            "RSA key generation could not use an isolated worker process "
+            "RSA key generation could not use an isolated subprocess "
             "(%s: %s); falling back to in-process generation, which will "
             "block the event loop for the duration of key generation.",
             type(err).__name__,

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -73,9 +73,22 @@ async def _generate_rsa_private_key_pem_isolated(key_size: int) -> bytes:
     no daemonic-process restriction. `asyncio.create_subprocess_exec` is
     awaited natively, off the loop by construction, including cancellation:
     killing and awaiting the child's exit are both async, so cancelling the
-    caller can't block the loop either. Raises on any exec or non-zero-exit
-    failure, so the caller can fall back to in-process generation.
+    caller can't block the loop either. Raises on any exec, non-zero-exit, or
+    empty-output failure, so the caller can fall back to in-process
+    generation.
+
+    In a frozen bundle (PyInstaller, cx_Freeze, py2exe), `sys.executable` is
+    the application itself, not a Python interpreter - `-c` would relaunch
+    the whole application rather than run this script, which can exit 0
+    without ever emitting a PEM. `sys.frozen` is the de facto marker these
+    freezers all set, so that case is refused up front instead of relying on
+    the empty-output check alone to catch it after the fact.
     """
+    if getattr(sys, "frozen", False):
+        raise RuntimeError(
+            "sys.executable is a frozen application bundle, not a Python "
+            "interpreter; it cannot run the RSA keygen script"
+        )
     proc = await asyncio.create_subprocess_exec(
         sys.executable,
         "-c",
@@ -96,7 +109,29 @@ async def _generate_rsa_private_key_pem_isolated(key_size: int) -> bytes:
             f"RSA key generation subprocess exited with code {proc.returncode}: "
             f"{stderr.decode(errors='replace').strip()}"
         )
+    if not stdout:
+        raise RuntimeError(
+            "RSA key generation subprocess exited successfully but produced no output"
+        )
     return stdout
+
+
+async def _deserialize_rsa_pem(pem: bytes) -> rsa.RSAPrivateKey:
+    """Deserialize a freshly generated RSA PEM off the event loop.
+
+    A malformed PEM (e.g. from a wrong-but-zero-exit isolated subprocess)
+    raises `ValueError` here rather than being trusted - the caller treats
+    that the same as any other isolation failure and falls back.
+    """
+    value = await asyncio.to_thread(
+        serialization.load_pem_private_key,
+        pem,
+        password=None,
+        backend=default_backend(),
+    )
+    if not isinstance(value, rsa.RSAPrivateKey):
+        raise AssertionError("Generated key is not an RSAPrivateKey")
+    return value
 
 
 async def _generate_rsa_private_key(key_size: int) -> tuple[rsa.RSAPrivateKey, bytes]:
@@ -107,13 +142,16 @@ async def _generate_rsa_private_key(key_size: int) -> tuple[rsa.RSAPrivateKey, b
     Falls back to in-process generation, which does block the loop, whenever
     that subprocess can't be used - the same environments this method could
     already generate keys in before process isolation was introduced. The
-    fallback catches any exception from launching or running the subprocess,
-    deliberately not enumerated by type, since process isolation is
-    best-effort here and any way it can fail should degrade to the working
-    (if blocking) legacy path rather than propagate.
+    fallback catches any exception from launching, running, or deserializing
+    the subprocess's output, deliberately not enumerated by type, since
+    process isolation is best-effort here and any way it can fail - including
+    producing a PEM that turns out not to deserialize - should degrade to the
+    working (if blocking) legacy path rather than propagate or return bad key
+    material.
     """
     try:
         pem = await _generate_rsa_private_key_pem_isolated(key_size)
+        value = await _deserialize_rsa_pem(pem)
     except Exception as err:
         LOGGER.warning(
             "RSA key generation could not use an isolated subprocess "
@@ -123,14 +161,7 @@ async def _generate_rsa_private_key(key_size: int) -> tuple[rsa.RSAPrivateKey, b
             err,
         )
         pem = await asyncio.to_thread(_generate_rsa_private_key_pem, key_size)
-    value = await asyncio.to_thread(
-        serialization.load_pem_private_key,
-        pem,
-        password=None,
-        backend=default_backend(),
-    )
-    if not isinstance(value, rsa.RSAPrivateKey):
-        raise AssertionError("Generated key is not an RSAPrivateKey")
+        value = await _deserialize_rsa_pem(pem)
     return value, pem
 
 

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -4,6 +4,8 @@ import base64
 import asyncio
 import os
 import time
+from concurrent.futures import ProcessPoolExecutor
+from multiprocessing import get_context
 from os.path import exists
 import aiofiles
 
@@ -20,6 +22,23 @@ from cryptography.hazmat.backends import default_backend
 
 _KEY_READ_RETRY_TIMEOUT = 1.0
 _KEY_READ_RETRY_INTERVAL = 0.05
+_RSA_KEY_GENERATION_EXECUTOR = ProcessPoolExecutor(
+    max_workers=1, mp_context=get_context("spawn")
+)
+
+
+def _generate_rsa_private_key_pem(key_size: int) -> bytes:
+    """Generate an RSA key outside the main process and return serialized material."""
+    key = rsa.generate_private_key(
+        public_exponent=65537,
+        key_size=key_size,
+        backend=default_backend(),
+    )
+    return key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.TraditionalOpenSSL,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
 
 
 def _owner_only_opener(file: str, flags: int) -> int:
@@ -153,17 +172,17 @@ class Tesla:
         the create race, its file is read instead of raising.
         """
         if not exists(path):
-            self.rsa_private_key = await asyncio.to_thread(
-                rsa.generate_private_key,
-                public_exponent=65537,
-                key_size=key_size,
-                backend=default_backend(),
+            pem = await asyncio.get_running_loop().run_in_executor(
+                _RSA_KEY_GENERATION_EXECUTOR,
+                _generate_rsa_private_key_pem,
+                key_size,
             )
-            pem = self.rsa_private_key.private_bytes(
-                encoding=serialization.Encoding.PEM,
-                format=serialization.PrivateFormat.TraditionalOpenSSL,
-                encryption_algorithm=serialization.NoEncryption(),
+            value = serialization.load_pem_private_key(
+                pem, password=None, backend=default_backend()
             )
+            if not isinstance(value, rsa.RSAPrivateKey):
+                raise AssertionError("Generated key is not an RSAPrivateKey")
+            self.rsa_private_key = value
             try:
                 async with aiofiles.open(
                     path, "wb", opener=_owner_only_opener

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -10,6 +10,7 @@ from multiprocessing import get_context
 from os.path import exists
 import aiofiles
 
+from tesla_fleet_api.const import LOGGER
 from tesla_fleet_api.tesla.charging import Charging
 from tesla_fleet_api.tesla.energysite import EnergySites
 from tesla_fleet_api.tesla.partner import Partner
@@ -44,29 +45,47 @@ def _generate_rsa_private_key_pem(key_size: int) -> bytes:
     )
 
 
-async def _generate_rsa_private_key(key_size: int) -> tuple[rsa.RSAPrivateKey, bytes]:
-    """Generate an RSA key in a short-lived worker process and return it with its PEM.
+async def _generate_rsa_private_key_pem_isolated(key_size: int) -> bytes:
+    """Generate an RSA key's PEM in a short-lived worker process.
 
     The pool is created fresh per call (not at import time) so importing this
     module never requires a spawn-safe entry point; only actually generating a
-    key does. `spawn` needs to re-import `__main__`, which fails under a REPL,
-    `python -c`, or a notebook cell - surfaced here as a clear error instead of
-    an opaque BrokenProcessPool.
+    key does. Raises `BrokenProcessPool`/`OSError` if the worker process or
+    its synchronization primitives can't start - e.g. `spawn` needs to
+    re-import `__main__`, which fails under a REPL, `python -c`, or a
+    notebook cell, or a restrictive umask blocks the pool's own semaphore
+    file - so the caller can fall back to in-process generation.
     """
     pool = ProcessPoolExecutor(max_workers=1, mp_context=get_context("spawn"))
     try:
-        pem = await asyncio.get_running_loop().run_in_executor(
+        return await asyncio.get_running_loop().run_in_executor(
             pool, _generate_rsa_private_key_pem, key_size
         )
-    except BrokenProcessPool as err:
-        raise RuntimeError(
-            "RSA key generation requires a subprocess-spawnable entry "
-            "point (a script or module guarded by "
-            "`if __name__ == '__main__':`); it cannot run from a REPL, "
-            "`python -c`, or a notebook cell."
-        ) from err
     finally:
         await asyncio.to_thread(pool.shutdown, wait=True, cancel_futures=True)
+
+
+async def _generate_rsa_private_key(key_size: int) -> tuple[rsa.RSAPrivateKey, bytes]:
+    """Generate an RSA key and return it with its PEM.
+
+    Prefers a short-lived worker process so keygen - which holds the GIL for
+    its full duration, unlike a thread - never stalls the caller's event
+    loop. Falls back to in-process generation, which does block the loop,
+    only when the environment can't support that worker process at all (no
+    spawn-importable `__main__`, or a restrictive umask blocking its
+    semaphore) - the same environments this method could already generate
+    keys in before process isolation was introduced.
+    """
+    try:
+        pem = await _generate_rsa_private_key_pem_isolated(key_size)
+    except (BrokenProcessPool, OSError) as err:
+        LOGGER.warning(
+            "RSA key generation could not use an isolated worker process "
+            "(%s); falling back to in-process generation, which will block "
+            "the event loop for the duration of key generation.",
+            err,
+        )
+        pem = await asyncio.to_thread(_generate_rsa_private_key_pem, key_size)
     value = await asyncio.to_thread(
         serialization.load_pem_private_key,
         pem,

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -5,7 +5,6 @@ import asyncio
 import os
 import time
 from concurrent.futures import ProcessPoolExecutor
-from concurrent.futures.process import BrokenProcessPool
 from multiprocessing import get_context
 from os.path import exists
 import aiofiles
@@ -50,11 +49,13 @@ async def _generate_rsa_private_key_pem_isolated(key_size: int) -> bytes:
 
     The pool is created fresh per call (not at import time) so importing this
     module never requires a spawn-safe entry point; only actually generating a
-    key does. Raises `BrokenProcessPool`/`OSError` if the worker process or
-    its synchronization primitives can't start - e.g. `spawn` needs to
-    re-import `__main__`, which fails under a REPL, `python -c`, or a
-    notebook cell, or a restrictive umask blocks the pool's own semaphore
-    file - so the caller can fall back to in-process generation.
+    key does. Process isolation is best-effort: pool creation or submission
+    can fail in ways this function does not attempt to enumerate - a
+    restrictive umask blocking the pool's own semaphore file,
+    `spawn` unable to re-import `__main__` from a REPL/`python -c`/notebook,
+    `AssertionError` from an already-daemonic calling process, or any other
+    environment that can't host a worker process - so the caller catches
+    broadly and falls back to in-process generation.
     """
     pool = ProcessPoolExecutor(max_workers=1, mp_context=get_context("spawn"))
     try:
@@ -71,18 +72,21 @@ async def _generate_rsa_private_key(key_size: int) -> tuple[rsa.RSAPrivateKey, b
     Prefers a short-lived worker process so keygen - which holds the GIL for
     its full duration, unlike a thread - never stalls the caller's event
     loop. Falls back to in-process generation, which does block the loop,
-    only when the environment can't support that worker process at all (no
-    spawn-importable `__main__`, or a restrictive umask blocking its
-    semaphore) - the same environments this method could already generate
-    keys in before process isolation was introduced.
+    whenever that worker process can't be used - the same environments this
+    method could already generate keys in before process isolation was
+    introduced. The fallback catches any exception from pool creation or
+    submission, deliberately not enumerated by type, since process isolation
+    is best-effort here and any way it can fail should degrade to the
+    working (if blocking) legacy path rather than propagate.
     """
     try:
         pem = await _generate_rsa_private_key_pem_isolated(key_size)
-    except (BrokenProcessPool, OSError) as err:
+    except Exception as err:
         LOGGER.warning(
             "RSA key generation could not use an isolated worker process "
-            "(%s); falling back to in-process generation, which will block "
-            "the event loop for the duration of key generation.",
+            "(%s: %s); falling back to in-process generation, which will "
+            "block the event loop for the duration of key generation.",
+            type(err).__name__,
             err,
         )
         pem = await asyncio.to_thread(_generate_rsa_private_key_pem, key_size)

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -53,18 +53,20 @@ async def _generate_rsa_private_key(key_size: int) -> tuple[rsa.RSAPrivateKey, b
     `python -c`, or a notebook cell - surfaced here as a clear error instead of
     an opaque BrokenProcessPool.
     """
-    with ProcessPoolExecutor(max_workers=1, mp_context=get_context("spawn")) as pool:
-        try:
-            pem = await asyncio.get_running_loop().run_in_executor(
-                pool, _generate_rsa_private_key_pem, key_size
-            )
-        except BrokenProcessPool as err:
-            raise RuntimeError(
-                "RSA key generation requires a subprocess-spawnable entry "
-                "point (a script or module guarded by "
-                "`if __name__ == '__main__':`); it cannot run from a REPL, "
-                "`python -c`, or a notebook cell."
-            ) from err
+    pool = ProcessPoolExecutor(max_workers=1, mp_context=get_context("spawn"))
+    try:
+        pem = await asyncio.get_running_loop().run_in_executor(
+            pool, _generate_rsa_private_key_pem, key_size
+        )
+    except BrokenProcessPool as err:
+        raise RuntimeError(
+            "RSA key generation requires a subprocess-spawnable entry "
+            "point (a script or module guarded by "
+            "`if __name__ == '__main__':`); it cannot run from a REPL, "
+            "`python -c`, or a notebook cell."
+        ) from err
+    finally:
+        await asyncio.to_thread(pool.shutdown, wait=True, cancel_futures=True)
     value = await asyncio.to_thread(
         serialization.load_pem_private_key,
         pem,

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -179,14 +179,14 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             self.assertEqual(mode, 0o600)
 
     async def test_new_key_file_is_owner_only_with_restrictive_umask(self) -> None:
-        # 0o077 (not 0o777, unlike the EC key's equivalent test above): a
-        # fully permission-devoid umask also blocks the multiprocessing
-        # worker's own internal semaphore file, unrelated to this method's
-        # own O_EXCL/fchmod permission handling, which this test targets.
+        # Under 0o777 the isolated worker process's own semaphore can't be
+        # created, so this exercises the in-process fallback - which, like
+        # the pre-process-isolation implementation, still produces a correct
+        # owner-only key file.
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
             tesla = Tesla()
-            old_umask = os.umask(0o077)
+            old_umask = os.umask(0o777)
             try:
                 await tesla.get_rsa_private_key(path, key_size=1024)
             finally:
@@ -371,8 +371,15 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
                 with self.assertRaises(asyncio.CancelledError):
                     await task
 
-    async def test_broken_process_pool_raises_clear_error(self) -> None:
-        """A spawn-incapable caller (REPL, `python -c`, notebook) gets a clear error."""
+    async def test_broken_process_pool_falls_back_to_in_process_generation(
+        self,
+    ) -> None:
+        """A spawn-incapable caller (REPL, `python -c`, notebook) still succeeds.
+
+        It falls back to in-process generation with a logged warning instead
+        of raising, matching the pre-process-isolation behavior these
+        environments already relied on.
+        """
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
 
@@ -389,12 +396,39 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
                 def shutdown(self, wait: bool, cancel_futures: bool) -> None:
                     pass
 
-            with mock.patch(
-                "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
-                return_value=_BrokenPool(),
+            with (
+                mock.patch(
+                    "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
+                    return_value=_BrokenPool(),
+                ),
+                self.assertLogs("tesla_fleet_api", level="WARNING") as logs,
             ):
-                with self.assertRaises(RuntimeError) as ctx:
-                    await Tesla().get_rsa_private_key(path, key_size=1024)
+                key = await Tesla().get_rsa_private_key(path, key_size=1024)
 
-            self.assertIn("spawn", str(ctx.exception))
-            self.assertIsInstance(ctx.exception.__cause__, BrokenProcessPool)
+            self.assertIsInstance(key, rsa.RSAPrivateKey)
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+            self.assertTrue(
+                any("isolated worker process" in message for message in logs.output)
+            )
+
+    async def test_pool_setup_oserror_falls_back_to_in_process_generation(self) -> None:
+        """A restrictive umask (or any other OSError at pool setup) also falls back."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+
+            with (
+                mock.patch(
+                    "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
+                    side_effect=PermissionError("boom"),
+                ),
+                self.assertLogs("tesla_fleet_api", level="WARNING") as logs,
+            ):
+                key = await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            self.assertIsInstance(key, rsa.RSAPrivateKey)
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+            self.assertTrue(
+                any("isolated worker process" in message for message in logs.output)
+            )

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -481,3 +481,108 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             self.assertTrue(
                 any("isolated subprocess" in message for message in logs.output)
             )
+
+    async def test_frozen_bundle_falls_back_to_in_process_generation(self) -> None:
+        """In a PyInstaller/cx_Freeze/py2exe bundle, `sys.executable` is the app itself.
+
+        `-c` would relaunch the whole application rather than run the keygen
+        script, so isolation is skipped up front (via `sys.frozen`, the de
+        facto marker these freezers all set) rather than relying on it to
+        exit non-zero or produce no output.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+
+            with (
+                mock.patch("tesla_fleet_api.tesla.tesla.sys.frozen", True, create=True),
+                mock.patch(
+                    "tesla_fleet_api.tesla.tesla.asyncio.create_subprocess_exec"
+                ) as create_subprocess_exec,
+                self.assertLogs("tesla_fleet_api", level="WARNING") as logs,
+            ):
+                key = await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            create_subprocess_exec.assert_not_called()
+            self.assertIsInstance(key, rsa.RSAPrivateKey)
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+            self.assertTrue(
+                any("isolated subprocess" in message for message in logs.output)
+            )
+
+    async def test_empty_subprocess_output_falls_back_to_in_process_generation(
+        self,
+    ) -> None:
+        """A subprocess that exits 0 but writes no PEM is treated as a failure.
+
+        Covers a wrong child (e.g. one that silently did nothing useful)
+        succeeding without ever emitting a key, which must not be trusted as
+        if it had.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+
+            class _EmptyOutputProc:
+                returncode = 0
+
+                async def communicate(self) -> tuple[bytes, bytes]:
+                    return b"", b""
+
+            async def fake_create_subprocess_exec(
+                *args: object, **kwargs: object
+            ) -> _EmptyOutputProc:
+                return _EmptyOutputProc()
+
+            with (
+                mock.patch(
+                    "tesla_fleet_api.tesla.tesla.asyncio.create_subprocess_exec",
+                    side_effect=fake_create_subprocess_exec,
+                ),
+                self.assertLogs("tesla_fleet_api", level="WARNING") as logs,
+            ):
+                key = await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            self.assertIsInstance(key, rsa.RSAPrivateKey)
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+            self.assertTrue(
+                any("isolated subprocess" in message for message in logs.output)
+            )
+
+    async def test_invalid_subprocess_pem_falls_back_to_in_process_generation(
+        self,
+    ) -> None:
+        """A subprocess that exits 0 with non-empty but malformed output also falls back.
+
+        Covers a wrong-but-zero-exit child whose output isn't a usable PEM at
+        all, which must not be trusted as if it had produced one.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+
+            class _GarbageOutputProc:
+                returncode = 0
+
+                async def communicate(self) -> tuple[bytes, bytes]:
+                    return b"not a pem", b""
+
+            async def fake_create_subprocess_exec(
+                *args: object, **kwargs: object
+            ) -> _GarbageOutputProc:
+                return _GarbageOutputProc()
+
+            with (
+                mock.patch(
+                    "tesla_fleet_api.tesla.tesla.asyncio.create_subprocess_exec",
+                    side_effect=fake_create_subprocess_exec,
+                ),
+                self.assertLogs("tesla_fleet_api", level="WARNING") as logs,
+            ):
+                key = await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            self.assertIsInstance(key, rsa.RSAPrivateKey)
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+            self.assertTrue(
+                any("isolated subprocess" in message for message in logs.output)
+            )

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -378,6 +378,46 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
 
             self.assertTrue(killed.is_set())
 
+    async def test_cancellation_preserves_cancel_when_subprocess_already_exited(
+        self,
+    ) -> None:
+        generation_started = asyncio.Event()
+        waited = asyncio.Event()
+
+        class _ExitedProc:
+            returncode = 0
+
+            async def communicate(self) -> tuple[bytes, bytes]:
+                generation_started.set()
+                await asyncio.Event().wait()
+                raise AssertionError("unreachable")
+
+            def kill(self) -> None:
+                raise ProcessLookupError
+
+            async def wait(self) -> int:
+                waited.set()
+                return self.returncode
+
+        async def fake_create_subprocess_exec(
+            *args: object, **kwargs: object
+        ) -> _ExitedProc:
+            return _ExitedProc()
+
+        with mock.patch(
+            "tesla_fleet_api.tesla.tesla.asyncio.create_subprocess_exec",
+            side_effect=fake_create_subprocess_exec,
+        ):
+            task = asyncio.create_task(
+                Tesla().get_rsa_private_key("unused.pem", key_size=1024)
+            )
+            await generation_started.wait()
+            task.cancel()
+            with self.assertRaises(asyncio.CancelledError):
+                await task
+
+        self.assertTrue(waited.is_set())
+
     async def test_subprocess_launch_failure_falls_back_to_in_process_generation(
         self,
     ) -> None:

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -10,9 +10,11 @@ winner's file instead of raising.
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import stat
 import os
 import tempfile
+from concurrent.futures.process import BrokenProcessPool
 from pathlib import Path
 from unittest import IsolatedAsyncioTestCase, mock
 
@@ -176,10 +178,14 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             self.assertEqual(mode, 0o600)
 
     async def test_new_key_file_is_owner_only_with_restrictive_umask(self) -> None:
+        # 0o077 (not 0o777, unlike the EC key's equivalent test above): a
+        # fully permission-devoid umask also blocks the multiprocessing
+        # worker's own internal semaphore file, unrelated to this method's
+        # own O_EXCL/fchmod permission handling, which this test targets.
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
             tesla = Tesla()
-            old_umask = os.umask(0o777)
+            old_umask = os.umask(0o077)
             try:
                 await tesla.get_rsa_private_key(path, key_size=1024)
             finally:
@@ -260,7 +266,14 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             self.assertEqual(_rsa_pem(key), _rsa_pem(winner_key))
 
     async def test_generation_does_not_block_the_event_loop(self) -> None:
-        """A concurrent heartbeat must keep ticking during real RSA generation."""
+        """A concurrent heartbeat must keep ticking during real RSA generation.
+
+        Generation runs in a separate worker process (a plain
+        ``asyncio.to_thread`` would not do - cryptography's RSA keygen holds
+        the GIL for its full duration, so a thread still stalls the caller's
+        event loop), which is why this uses a real key rather than a mocked
+        stand-in: only genuine process isolation proves the loop stays free.
+        """
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
 
@@ -280,3 +293,72 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
 
             self.assertGreater(ticks, 5)
             self.assertEqual(_rsa_pem(key), Path(path).read_bytes())
+
+    async def test_deserialization_does_not_block_the_event_loop(self) -> None:
+        """The post-generation PEM deserialization also must not stall the loop.
+
+        It runs in the main process (via ``asyncio.to_thread``), so unlike
+        generation it can be exercised with a mocked slow stand-in.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            real_key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
+
+            def slow_load_pem_private_key(
+                *args: object, **kwargs: object
+            ) -> rsa.RSAPrivateKey:
+                import time as time_module
+
+                time_module.sleep(0.15)
+                return real_key
+
+            ticks = 0
+
+            async def heartbeat() -> None:
+                nonlocal ticks
+                while True:
+                    await asyncio.sleep(0.01)
+                    ticks += 1
+
+            with mock.patch(
+                "tesla_fleet_api.tesla.tesla.serialization.load_pem_private_key",
+                side_effect=slow_load_pem_private_key,
+            ):
+                heart = asyncio.create_task(heartbeat())
+                try:
+                    await Tesla().get_rsa_private_key(path, key_size=1024)
+                finally:
+                    heart.cancel()
+
+            self.assertGreater(ticks, 10)
+
+    async def test_broken_process_pool_raises_clear_error(self) -> None:
+        """A spawn-incapable caller (REPL, `python -c`, notebook) gets a clear error."""
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+
+            class _BrokenPool:
+                def __enter__(self) -> "_BrokenPool":
+                    return self
+
+                def __exit__(self, *exc_info: object) -> bool:
+                    return False
+
+                def submit(
+                    self, fn: object, *args: object, **kwargs: object
+                ) -> concurrent.futures.Future[bytes]:
+                    future: concurrent.futures.Future[bytes] = (
+                        concurrent.futures.Future()
+                    )
+                    future.set_exception(BrokenProcessPool("boom"))
+                    return future
+
+            with mock.patch(
+                "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
+                return_value=_BrokenPool(),
+            ):
+                with self.assertRaises(RuntimeError) as ctx:
+                    await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            self.assertIn("spawn", str(ctx.exception))
+            self.assertIsInstance(ctx.exception.__cause__, BrokenProcessPool)

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -11,9 +11,10 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
-import stat
 import os
+import stat
 import tempfile
+import threading
 from concurrent.futures.process import BrokenProcessPool
 from pathlib import Path
 from unittest import IsolatedAsyncioTestCase, mock
@@ -332,18 +333,50 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
 
             self.assertGreater(ticks, 10)
 
+    async def test_cancellation_does_not_block_the_event_loop(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            generation_started = asyncio.Event()
+            shutdown_started = threading.Event()
+            release_shutdown = threading.Event()
+
+            class _SlowPool:
+                def submit(
+                    self, fn: object, *args: object, **kwargs: object
+                ) -> concurrent.futures.Future[bytes]:
+                    future: concurrent.futures.Future[bytes] = (
+                        concurrent.futures.Future()
+                    )
+                    generation_started.set()
+                    return future
+
+                def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+                    shutdown_started.set()
+                    release_shutdown.wait()
+
+            with mock.patch(
+                "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
+                return_value=_SlowPool(),
+            ):
+                task = asyncio.create_task(
+                    Tesla().get_rsa_private_key(path, key_size=1024)
+                )
+                await generation_started.wait()
+                task.cancel()
+                await asyncio.wait_for(
+                    asyncio.to_thread(shutdown_started.wait), timeout=0.1
+                )
+                await asyncio.sleep(0)
+                release_shutdown.set()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+
     async def test_broken_process_pool_raises_clear_error(self) -> None:
         """A spawn-incapable caller (REPL, `python -c`, notebook) gets a clear error."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
 
             class _BrokenPool:
-                def __enter__(self) -> "_BrokenPool":
-                    return self
-
-                def __exit__(self, *exc_info: object) -> bool:
-                    return False
-
                 def submit(
                     self, fn: object, *args: object, **kwargs: object
                 ) -> concurrent.futures.Future[bytes]:
@@ -352,6 +385,9 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
                     )
                     future.set_exception(BrokenProcessPool("boom"))
                     return future
+
+                def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+                    pass
 
             with mock.patch(
                 "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -258,3 +258,40 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
                 await writer
 
             self.assertEqual(_rsa_pem(key), _rsa_pem(winner_key))
+
+    async def test_generation_does_not_block_the_event_loop(self) -> None:
+        """A concurrent heartbeat must keep ticking while the key is generated.
+
+        Generation blocks a real OS thread (started via ``asyncio.to_thread``),
+        not the event loop, so a plain time.sleep stand-in for the CPU-bound
+        call proves the loop stays responsive.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            real_key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
+
+            def slow_generate(*args: object, **kwargs: object) -> rsa.RSAPrivateKey:
+                import time as time_module
+
+                time_module.sleep(0.3)
+                return real_key
+
+            ticks = 0
+
+            async def heartbeat() -> None:
+                nonlocal ticks
+                while True:
+                    await asyncio.sleep(0.01)
+                    ticks += 1
+
+            with mock.patch(
+                "tesla_fleet_api.tesla.tesla.rsa.generate_private_key",
+                side_effect=slow_generate,
+            ):
+                heart = asyncio.create_task(heartbeat())
+                try:
+                    await Tesla().get_rsa_private_key(path, key_size=1024)
+                finally:
+                    heart.cancel()
+
+            self.assertGreater(ticks, 5)

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -260,21 +260,9 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             self.assertEqual(_rsa_pem(key), _rsa_pem(winner_key))
 
     async def test_generation_does_not_block_the_event_loop(self) -> None:
-        """A concurrent heartbeat must keep ticking while the key is generated.
-
-        Generation blocks a real OS thread (started via ``asyncio.to_thread``),
-        not the event loop, so a plain time.sleep stand-in for the CPU-bound
-        call proves the loop stays responsive.
-        """
+        """A concurrent heartbeat must keep ticking during real RSA generation."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
-            real_key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
-
-            def slow_generate(*args: object, **kwargs: object) -> rsa.RSAPrivateKey:
-                import time as time_module
-
-                time_module.sleep(0.3)
-                return real_key
 
             ticks = 0
 
@@ -284,14 +272,11 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
                     await asyncio.sleep(0.01)
                     ticks += 1
 
-            with mock.patch(
-                "tesla_fleet_api.tesla.tesla.rsa.generate_private_key",
-                side_effect=slow_generate,
-            ):
-                heart = asyncio.create_task(heartbeat())
-                try:
-                    await Tesla().get_rsa_private_key(path, key_size=1024)
-                finally:
-                    heart.cancel()
+            heart = asyncio.create_task(heartbeat())
+            try:
+                key = await Tesla().get_rsa_private_key(path, key_size=4096)
+            finally:
+                heart.cancel()
 
             self.assertGreater(ticks, 5)
+            self.assertEqual(_rsa_pem(key), Path(path).read_bytes())

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -432,3 +432,44 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             self.assertTrue(
                 any("isolated worker process" in message for message in logs.output)
             )
+
+    async def test_daemonic_caller_assertion_error_falls_back_to_in_process_generation(
+        self,
+    ) -> None:
+        """A caller already running as a daemonic multiprocessing worker also falls back.
+
+        `multiprocessing.Process.start()` raises a bare `AssertionError`
+        ("daemonic processes are not allowed to have children") in that case
+        - a failure shape outside any specific exception type, which is why
+        the fallback catches broadly rather than enumerating types.
+        """
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+
+            class _DaemonicPool:
+                def submit(
+                    self, fn: object, *args: object, **kwargs: object
+                ) -> concurrent.futures.Future[bytes]:
+                    raise AssertionError(
+                        "daemonic processes are not allowed to have children"
+                    )
+
+                def shutdown(self, wait: bool, cancel_futures: bool) -> None:
+                    pass
+
+            with (
+                mock.patch(
+                    "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
+                    return_value=_DaemonicPool(),
+                ),
+                self.assertLogs("tesla_fleet_api", level="WARNING") as logs,
+            ):
+                key = await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            self.assertIsInstance(key, rsa.RSAPrivateKey)
+            mode = stat.S_IMODE(Path(path).stat().st_mode)
+            self.assertEqual(mode, 0o600)
+            self.assertTrue(
+                any("isolated worker process" in message for message in logs.output)
+            )
+            self.assertTrue(any("AssertionError" in message for message in logs.output))

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -10,12 +10,9 @@ winner's file instead of raising.
 from __future__ import annotations
 
 import asyncio
-import concurrent.futures
 import os
 import stat
 import tempfile
-import threading
-from concurrent.futures.process import BrokenProcessPool
 from pathlib import Path
 from unittest import IsolatedAsyncioTestCase, mock
 
@@ -179,10 +176,11 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             self.assertEqual(mode, 0o600)
 
     async def test_new_key_file_is_owner_only_with_restrictive_umask(self) -> None:
-        # Under 0o777 the isolated worker process's own semaphore can't be
-        # created, so this exercises the in-process fallback - which, like
-        # the pre-process-isolation implementation, still produces a correct
-        # owner-only key file.
+        # Unlike multiprocessing's semaphore file, a plain subprocess has no
+        # umask-sensitive IPC of its own, so this exercises the isolated
+        # subprocess path directly (no fallback needed) and still produces a
+        # correct owner-only key file via _owner_only_opener's explicit
+        # fchmod, which bypasses umask entirely.
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
             tesla = Tesla()
@@ -333,73 +331,71 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
 
             self.assertGreater(ticks, 10)
 
-    async def test_cancellation_does_not_block_the_event_loop(self) -> None:
+    async def test_cancellation_kills_the_subprocess(self) -> None:
+        """Cancelling mid-generation kills the child rather than leaving it orphaned.
+
+        Killing and awaiting the child's exit are both async operations, so
+        this also can't block the event loop the way a synchronous
+        `ProcessPoolExecutor.shutdown(wait=True)` could.
+        """
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
             generation_started = asyncio.Event()
-            shutdown_started = threading.Event()
-            release_shutdown = threading.Event()
+            killed = asyncio.Event()
 
-            class _SlowPool:
-                def submit(
-                    self, fn: object, *args: object, **kwargs: object
-                ) -> concurrent.futures.Future[bytes]:
-                    future: concurrent.futures.Future[bytes] = (
-                        concurrent.futures.Future()
-                    )
+            class _SlowProc:
+                returncode: int | None = None
+
+                async def communicate(self) -> tuple[bytes, bytes]:
                     generation_started.set()
-                    return future
+                    await asyncio.Event().wait()  # never resolves on its own
+                    raise AssertionError("unreachable")
 
-                def shutdown(self, wait: bool, cancel_futures: bool) -> None:
-                    shutdown_started.set()
-                    release_shutdown.wait()
+                def kill(self) -> None:
+                    killed.set()
+
+                async def wait(self) -> int:
+                    await killed.wait()
+                    self.returncode = -9
+                    return self.returncode
+
+            async def fake_create_subprocess_exec(
+                *args: object, **kwargs: object
+            ) -> _SlowProc:
+                return _SlowProc()
 
             with mock.patch(
-                "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
-                return_value=_SlowPool(),
+                "tesla_fleet_api.tesla.tesla.asyncio.create_subprocess_exec",
+                side_effect=fake_create_subprocess_exec,
             ):
                 task = asyncio.create_task(
                     Tesla().get_rsa_private_key(path, key_size=1024)
                 )
                 await generation_started.wait()
                 task.cancel()
-                await asyncio.wait_for(
-                    asyncio.to_thread(shutdown_started.wait), timeout=0.1
-                )
-                await asyncio.sleep(0)
-                release_shutdown.set()
                 with self.assertRaises(asyncio.CancelledError):
                     await task
 
-    async def test_broken_process_pool_falls_back_to_in_process_generation(
+            self.assertTrue(killed.is_set())
+
+    async def test_subprocess_launch_failure_falls_back_to_in_process_generation(
         self,
     ) -> None:
-        """A spawn-incapable caller (REPL, `python -c`, notebook) still succeeds.
+        """A caller whose environment can't launch the subprocess still succeeds.
 
-        It falls back to in-process generation with a logged warning instead
-        of raising, matching the pre-process-isolation behavior these
-        environments already relied on.
+        Falls back to in-process generation with a logged warning instead of
+        raising, matching the pre-process-isolation behavior. The fallback
+        deliberately isn't specific to any one launch-failure cause (a
+        restrictive umask, a REPL/notebook caller, a sandboxed environment
+        without `sys.executable`, ...) - any of them lands here the same way.
         """
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
 
-            class _BrokenPool:
-                def submit(
-                    self, fn: object, *args: object, **kwargs: object
-                ) -> concurrent.futures.Future[bytes]:
-                    future: concurrent.futures.Future[bytes] = (
-                        concurrent.futures.Future()
-                    )
-                    future.set_exception(BrokenProcessPool("boom"))
-                    return future
-
-                def shutdown(self, wait: bool, cancel_futures: bool) -> None:
-                    pass
-
             with (
                 mock.patch(
-                    "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
-                    return_value=_BrokenPool(),
+                    "tesla_fleet_api.tesla.tesla.asyncio.create_subprocess_exec",
+                    side_effect=OSError("boom"),
                 ),
                 self.assertLogs("tesla_fleet_api", level="WARNING") as logs,
             ):
@@ -409,58 +405,31 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             mode = stat.S_IMODE(Path(path).stat().st_mode)
             self.assertEqual(mode, 0o600)
             self.assertTrue(
-                any("isolated worker process" in message for message in logs.output)
+                any("isolated subprocess" in message for message in logs.output)
             )
 
-    async def test_pool_setup_oserror_falls_back_to_in_process_generation(self) -> None:
-        """A restrictive umask (or any other OSError at pool setup) also falls back."""
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
-
-            with (
-                mock.patch(
-                    "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
-                    side_effect=PermissionError("boom"),
-                ),
-                self.assertLogs("tesla_fleet_api", level="WARNING") as logs,
-            ):
-                key = await Tesla().get_rsa_private_key(path, key_size=1024)
-
-            self.assertIsInstance(key, rsa.RSAPrivateKey)
-            mode = stat.S_IMODE(Path(path).stat().st_mode)
-            self.assertEqual(mode, 0o600)
-            self.assertTrue(
-                any("isolated worker process" in message for message in logs.output)
-            )
-
-    async def test_daemonic_caller_assertion_error_falls_back_to_in_process_generation(
+    async def test_subprocess_nonzero_exit_falls_back_to_in_process_generation(
         self,
     ) -> None:
-        """A caller already running as a daemonic multiprocessing worker also falls back.
-
-        `multiprocessing.Process.start()` raises a bare `AssertionError`
-        ("daemonic processes are not allowed to have children") in that case
-        - a failure shape outside any specific exception type, which is why
-        the fallback catches broadly rather than enumerating types.
-        """
+        """A subprocess that launches but exits non-zero also falls back."""
         with tempfile.TemporaryDirectory() as tmp_dir:
             path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
 
-            class _DaemonicPool:
-                def submit(
-                    self, fn: object, *args: object, **kwargs: object
-                ) -> concurrent.futures.Future[bytes]:
-                    raise AssertionError(
-                        "daemonic processes are not allowed to have children"
-                    )
+            class _FailingProc:
+                returncode = 1
 
-                def shutdown(self, wait: bool, cancel_futures: bool) -> None:
-                    pass
+                async def communicate(self) -> tuple[bytes, bytes]:
+                    return b"", b"boom"
+
+            async def fake_create_subprocess_exec(
+                *args: object, **kwargs: object
+            ) -> _FailingProc:
+                return _FailingProc()
 
             with (
                 mock.patch(
-                    "tesla_fleet_api.tesla.tesla.ProcessPoolExecutor",
-                    return_value=_DaemonicPool(),
+                    "tesla_fleet_api.tesla.tesla.asyncio.create_subprocess_exec",
+                    side_effect=fake_create_subprocess_exec,
                 ),
                 self.assertLogs("tesla_fleet_api", level="WARNING") as logs,
             ):
@@ -470,6 +439,5 @@ class GetRsaPrivateKeyPermissionsTests(IsolatedAsyncioTestCase):
             mode = stat.S_IMODE(Path(path).stat().st_mode)
             self.assertEqual(mode, 0o600)
             self.assertTrue(
-                any("isolated worker process" in message for message in logs.output)
+                any("isolated subprocess" in message for message in logs.output)
             )
-            self.assertTrue(any("AssertionError" in message for message in logs.output))


### PR DESCRIPTION
## Intent

Address Codex round 6 on PR #105: a real gap in the round-5 plain-subprocess design. In a frozen bundle (PyInstaller, cx_Freeze, py2exe), sys.executable is the application itself, not a Python interpreter, so launching it with -c <script> would relaunch the whole application - a recursive-spawn risk at startup - and that relaunch can exit 0 without ever emitting a PEM, which dodges the existing catch-all fallback entirely since nothing raises to trigger it. Added a surgical pre-flight check in _generate_rsa_private_key_pem_isolated: if getattr(sys, 'frozen', False) (the de facto marker PyInstaller/cx_Freeze/py2exe all set - there is no other stdlib-documented equivalent beyond this one attribute), raise before ever attempting the subprocess, which flows through the exact same except-Exception-then-fallback path already in _generate_rsa_private_key - consistent with the best-effort-isolation contract, no special-casing needed at the call site. Also hardened the success path per the same finding, per instruction to treat an empty or invalid PEM from the child as failure rather than letting a wrong-but-zero-exit child poison deserialization: an empty stdout (returncode 0, no output) now raises immediately in the isolated helper before ever reaching deserialization; and deserialization itself (extracted into a new shared _deserialize_rsa_pem helper used by both the isolated and fallback paths) now happens INSIDE the try/except in _generate_rsa_private_key rather than after it, so a subprocess that exits 0 with non-empty but malformed/garbage output also triggers the warning+fallback instead of letting a ValueError from load_pem_private_key propagate uncaught. This keeps the happy path's cost unchanged (one deserialization) and only pays a second deserialization in the rare case where the isolated path's output turns out to be unusable. Added three tests: test_frozen_bundle_falls_back_to_in_process_generation (mocks sys.frozen=True, asserts create_subprocess_exec is never called and generation still succeeds via fallback with the warning logged), test_empty_subprocess_output_falls_back_to_in_process_generation (a fake process with returncode 0 and empty stdout/stderr), and test_invalid_subprocess_pem_falls_back_to_in_process_generation (returncode 0 with non-empty but non-PEM stdout). All three assert success via fallback, the key file lands owner-only, and the warning log mentions the isolated subprocess. Full suite (517 tests), pyright strict, and ruff all pass locally; manually verified end-to-end that setting sys.frozen=True triggers the warning and successful fallback.

## What Changed

- Generate new RSA private keys in a short-lived subprocess to avoid blocking the asyncio event loop, with cancellation-safe child cleanup.
- Fall back to in-process generation when isolation is unavailable or returns invalid output, including frozen application bundles, while preserving secure key persistence.
- Document the isolation and fallback behavior and add coverage for responsiveness, cancellation, subprocess failures, and malformed output.

## Risk Assessment

✅ Low: The frozen-runtime preflight and shared deserialization path close the stated recursive-spawn and invalid-output gaps while preserving cancellation and fallback behavior.

## Testing

Targeted tests exercised frozen-app subprocess avoidance, zero-exit empty output, and malformed non-empty output; all successfully fell back. An end-to-end transcript confirms the frozen path logs the expected warning, persists a valid matching RSA key, and creates it with owner-only mode `0600`; transient worktree test artifacts were removed.

<details>
<summary>Evidence: Frozen-bundle fallback transcript</summary>

```text
WARNING:tesla_fleet_api:RSA key generation could not use an isolated subprocess (RuntimeError: sys.executable is a frozen application bundle, not a Python interpreter; it cannot run the RSA keygen script); falling back to in-process generation, which will block the event loop for the duration of key generation.
generated_type=RSAPrivateKey
persisted_rsa=True
key_matches_file=True
file_mode=-rw------- (0o600)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `uv run pytest -q tests/test_tesla_private_key.py::GetRsaPrivateKeyPermissionsTests::test_frozen_bundle_falls_back_to_in_process_generation tests/test_tesla_private_key.py::GetRsaPrivateKeyPermissionsTests::test_empty_subprocess_output_falls_back_to_in_process_generation tests/test_tesla_private_key.py::GetRsaPrivateKeyPermissionsTests::test_invalid_subprocess_pem_falls_back_to_in_process_generation`
- <code>Manual `sys.frozen=True` invocation of `Tesla.get_rsa_private_key`, followed by persisted-PEM deserialization, generated/persisted key comparison, warning inspection, and file-mode verification</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
