### PR TITLE
feat(vehicle): add Cybercab (VIN 4th-char A) to model detection

### DIFF
--- a/tesla_fleet_api.egg-info/SOURCES.txt
+++ b/tesla_fleet_api.egg-info/SOURCES.txt
@@ -100,3 +100,4 @@ tests/test_teslemetry_gateway_address.py
 tests/test_teslemetry_wait_until_paired.py
 tests/test_tessie_vehicle_params.py
 tests/test_vehicle_image_state.py
+tests/test_vehicle_model.py

--- a/tesla_fleet_api/tesla/vehicle/vehicle.py
+++ b/tesla_fleet_api/tesla/vehicle/vehicle.py
@@ -15,6 +15,7 @@ MODELS = {
     "C": "Cybertruck",
     "R": "Roadster",
     "T": "Semi",
+    "A": "Cybercab",
 }
 
 

--- a/tests/test_vehicle_model.py
+++ b/tests/test_vehicle_model.py
@@ -1,0 +1,39 @@
+"""Model detection from the VIN's 4th character (Vehicle.model)."""
+
+from unittest import TestCase
+
+from tesla_fleet_api.tesla.vehicle.vehicle import Vehicle
+
+
+class VehicleModelTests(TestCase):
+    def _model_for(self, fourth_char: str) -> str:
+        vin = f"5YJ{fourth_char}CAE43LF123456"
+        vehicle = Vehicle(parent=None, vin=vin)
+        return vehicle.model
+
+    def test_model_s(self):
+        self.assertEqual(self._model_for("S"), "Model S")
+
+    def test_model_x(self):
+        self.assertEqual(self._model_for("X"), "Model X")
+
+    def test_model_3(self):
+        self.assertEqual(self._model_for("3"), "Model 3")
+
+    def test_model_y(self):
+        self.assertEqual(self._model_for("Y"), "Model Y")
+
+    def test_cybertruck(self):
+        self.assertEqual(self._model_for("C"), "Cybertruck")
+
+    def test_roadster(self):
+        self.assertEqual(self._model_for("R"), "Roadster")
+
+    def test_semi(self):
+        self.assertEqual(self._model_for("T"), "Semi")
+
+    def test_cybercab(self):
+        self.assertEqual(self._model_for("A"), "Cybercab")
+
+    def test_unknown(self):
+        self.assertEqual(self._model_for("Z"), "Unknown")


### PR DESCRIPTION
## Intent
- Vehicle models are identified by the VIN's 4th character; Tesla's new Cybercab uses `A`.
  - Add `"A": "Cybercab"` to the `MODELS` mapping in `tesla_fleet_api/tesla/vehicle/vehicle.py`, the only model-derivation site in the repo.
  - No Cybercab-specific behavior invented; it gets whatever the generic model treatment provides.
  - Added `tests/test_vehicle_model.py` covering all `MODELS` letters plus Cybercab and the unknown fallback.

Pipeline skip: trivial additive one-line mapping + test, per captain directive; full suite/lint/typecheck run locally and green instead of routing through no-mistakes.