### PR TITLE
ci: split lint/test/build jobs and add distribution artifact check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,8 +6,24 @@ on:
   pull_request:
 
 jobs:
-  check:
-    name: Lint, typecheck, test (py${{ matrix.python-version }})
+  lint:
+    name: Lint & type-check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Install dependencies
+        run: uv sync
+      - name: Ruff
+        run: uv run ruff check tesla_fleet_api tests
+      - name: Pyright
+        run: uv run pyright tesla_fleet_api
+
+  test:
+    name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -23,9 +39,24 @@ jobs:
         run: uv python install ${{ matrix.python-version }}
       - name: Install dependencies
         run: uv sync --python ${{ matrix.python-version }}
-      - name: Ruff lint
-        run: uv run ruff check tesla_fleet_api tests
-      - name: Pyright
-        run: uv run pyright tesla_fleet_api
       - name: Pytest
         run: uv run pytest tests -q
+
+  build:
+    name: Build distribution
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+      - name: Build
+        run: uv build
+      - name: Check distribution
+        run: uvx twine check dist/*
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*


### PR DESCRIPTION
## Intent

Standardize this repo's CI on the same lint/type/test/build job shape used across the Python trio (`aiopowerwall`, `python-teslemetry-stream`), per the O10 CI/release inventory (E10.1-S6).

- Split the single combined `check` job into `lint`, `test`, and `build` jobs
  - `lint`: Ruff + Pyright, once (was previously re-run per matrix entry)
  - `test`: Pytest, still matrixed over the repo's supported Python versions (currently just `3.13`, matching `requires-python`)
  - `build` (new): `uv build` for wheel/sdist, `twine check` on the artifacts, uploaded as a workflow artifact
- No trigger or matrix changes - same `push`/`pull_request` gating, same Python version(s) as before
