### PR TITLE
Bump version to 1.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.8.0"
+version = "1.8.1"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.8.0"
+__version__ = "1.8.1"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.tariff import (

--- a/uv.lock
+++ b/uv.lock
@@ -740,7 +740,7 @@ wheels = [
 
 [[package]]
 name = "tesla-fleet-api"
-version = "1.8.0"
+version = "1.8.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Intent
- Bump `version`/`__version__` from 1.8.0 to 1.8.1 to release the two unreleased commits on `main`
- No behavior changes in this PR itself; pushing the `v1.8.1` tag afterward is what publishes to PyPI (`.github/workflows/python-publish.yml` fires on tag push, not on merge)

## Changes going into 1.8.1
- fix(tesla): honor runtime BLE client bindings (#111)
- fix(tesla): reduce BLE connection retry delay (#114)
