### PR TITLE
fix(ci): disable PyPI attestations for reusable-workflow publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,9 @@ jobs:
           path: dist/
       - name: Publish distribution to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Reusable-workflow identity mismatch breaks PyPI attestation verification (PEP 740).
+          attestations: false
 
   github-release:
     name: Upload distribution to GitHub Release


### PR DESCRIPTION
## Intent

- The tagged `v1.8.1` publish 400'd with "Invalid attestations supplied" and never reached PyPI.
  - `pypa/gh-action-pypi-publish` signs PEP 740 attestations under the top-level workflow's OIDC identity, but PyPI verifies them against the reusable `release.yml` workflow's own publisher identity — a known limitation when the publish step lives in a `workflow_call` workflow.
  - Set `attestations: false` on the publish step so the upload matches the identity PyPI already trusts for this reusable workflow.
