### PR TITLE
fix(ci): use literal environment name/url in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,8 +48,8 @@ jobs:
     needs: gate
     runs-on: ubuntu-latest
     environment:
-      name: ${{ env.ENVIRONMENT_NAME }}
-      url: ${{ env.PYPI_PROJECT_URL }}
+      name: pypi
+      url: https://pypi.org/p/tesla_fleet_api
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Fixes the release workflow so tag pushes actually run: the `publish-to-pypi` job's `environment:` key interpolated `${{ env.ENVIRONMENT_NAME }}` / `${{ env.PYPI_PROJECT_URL }}`, but GitHub Actions cannot evaluate the `env` context in a job-level `environment:` key. This caused every tag push (including `v1.9.0`) to schedule 0 jobs and fail immediately, before any check run was even created.

Replaces both with literal values (`name: pypi`, the literal PyPI project URL) — no other changes.

Once this merges, `v1.9.0`'s publish will be re-triggered (re-push the tag at the new merge commit) to actually gate CI and publish to PyPI.
