### PR TITLE
feat(tessie): add set_roles command for payer role assignment

### DIFF
--- a/docs/tessie.md
+++ b/docs/tessie.md
@@ -415,6 +415,9 @@ async def main():
         response = await vehicle.delete_driver(id=1)
         print(response)
 
+        response = await vehicle.set_roles(role="SUBSCRIPTION", account_id="555555555")
+        print(response)
+
         response = await vehicle.get_fleet_telemetry_config()
         print(response)
 

--- a/tesla_fleet_api/tessie/vehicle.py
+++ b/tesla_fleet_api/tessie/vehicle.py
@@ -1080,6 +1080,20 @@ class TessieVehicle(VehicleFleet["Tessie"]):
             f"{self.vin}/invitations/{id}/revoke",
         )
 
+    async def set_roles(
+        self,
+        role: str,
+        account_id: str | None = None,
+        federation_id: str | None = None,
+    ) -> dict[str, Any]:
+        """Assign the subscription or charging payer role (requires a Tesla Business account)."""
+        payload: dict[str, str] = {"role": role}
+        if account_id is not None:
+            payload["account_id"] = account_id
+        if federation_id is not None:
+            payload["federation_id"] = federation_id
+        return await self._request(Method.POST, f"{self.vin}/roles", json=payload)
+
     # Fleet Telemetry
     async def get_fleet_telemetry_config(self) -> dict[str, Any]:
         """Retrieve telemetry configuration."""

--- a/tests/test_tessie_vehicle_params.py
+++ b/tests/test_tessie_vehicle_params.py
@@ -250,7 +250,40 @@ class TessieVehicleParameterTests(IsolatedAsyncioTestCase):
                 lon=4.56,
             )
 
-    async def test_tessie_add_precondition_schedule_uses_documented_parameters(self) -> None:
+    async def test_set_roles_uses_documented_parameters(self) -> None:
+        """set_roles should send the documented JSON body with only provided fields."""
+
+        vehicle, request = self.create_vehicle()
+
+        response = await vehicle.set_roles(
+            role="SUBSCRIPTION",
+            account_id="555555555",
+        )
+
+        self.assertEqual(response, {"result": True})
+        request.assert_awaited_once_with(
+            Method.POST,
+            f"{self.VIN}/roles",
+            json={"role": "SUBSCRIPTION", "account_id": "555555555"},
+        )
+
+    async def test_set_roles_omits_unset_optional_fields(self) -> None:
+        """set_roles should omit account_id/federation_id when not provided."""
+
+        vehicle, request = self.create_vehicle()
+
+        response = await vehicle.set_roles(role="CHARGING")
+
+        self.assertEqual(response, {"result": True})
+        request.assert_awaited_once_with(
+            Method.POST,
+            f"{self.VIN}/roles",
+            json={"role": "CHARGING"},
+        )
+
+    async def test_tessie_add_precondition_schedule_uses_documented_parameters(
+        self,
+    ) -> None:
         """Precondition schedule requests should follow the Tessie schema."""
 
         vehicle, request = self.create_vehicle()


### PR DESCRIPTION
## Intent

Bring the Tessie class to full command parity with Tessie's documented command surface (developer.tessie.com), verified live rather than from memory. Enumerated every POST /{vin}/command/* and /{vin}/wake endpoint plus related action endpoints from the current openapi.yaml, then diffed against TessieVehicle's existing methods. Result: the class already implemented every documented vehicle command from a prior comprehensive-coverage pass; the only gap found was POST /{vin}/roles ('Set Roles'), a Tesla-Business-only command to assign the subscription/charging payer role, which had no library method (the sibling GET /{vin}/roles is a data/read endpoint and is intentionally out of scope). Added set_roles(role, account_id=None, federation_id=None) on TessieVehicle following the existing JSON-body command convention used by delete_driver/update_plate (POST with a json= payload, optional fields omitted when None, no wait_for_completion/max_attempts since the endpoint doesn't support them per the spec). No collision with any parent-class method name, so no tessie_ prefix was needed (that prefix convention is reserved for names already defined on VehicleFleet). No deprecated or beta-marked commands exist in the current spec, so there is nothing to exclude on that basis. Added unit tests mirroring the existing test_tessie_vehicle_params.py style (mocked _request, asserting the exact JSON body sent, including the omitted-optional-fields case) and a docs/tessie.md usage example in the same list-of-calls style as neighboring commands. Scope is intentionally narrow: Tessie command parity only - no data/telemetry endpoint work, no refactors, no version bump. Ruff, pyright (strict), and the full pytest suite (596 tests) are all green locally.

## What Changed

- Added `TessieVehicle.set_roles(role, account_id=None, federation_id=None)`, a POST `/{vin}/roles` command that assigns the subscription/charging payer role on a Tesla Business account, following the same JSON-body command convention as `delete_driver`/`update_plate` (optional fields omitted from the payload when unset).
- Added `docs/tessie.md` usage example for `set_roles` alongside the other vehicle command examples.
- Added unit tests in `tests/test_tessie_vehicle_params.py` asserting the exact JSON body sent, including the case where optional fields are omitted.

## Risk Assessment

✅ Low: Small, self-contained addition (one new method + doc line + two unit tests) that follows the existing delete_driver/update_plate JSON-body convention exactly, has no naming collision with VehicleFleet requiring a tessie_ prefix, and is fully covered by tests matching the documented endpoint and optional-field-omission behavior.

## Testing

Ran the targeted test_tessie_vehicle_params.py suite (7/7 passed) covering the new set_roles unit tests, and separately drove TessieVehicle.set_roles() through a manual mocked-request script exercising all three field combinations to directly observe the exact POST /{vin}/roles JSON payload built — confirming required-only, full, and federation_id-variant calls all match the documented Tessie command convention with optional fields correctly omitted when unset. No issues found; working tree left clean (reverted incidental uv-generated egg-info/uv.lock churn from running the toolchain).

<details>
<summary>Evidence: Manual end-to-end verification of set_roles() request construction</summary>

<code>Call 1 (role+account_id) -&gt; request call: call(&lt;Method.POST: &#39;POST&#39;&gt;, &#39;5YJXCAE43LF123456/roles&#39;, json={&#39;role&#39;: &#39;SUBSCRIPTION&#39;, &#39;account_id&#39;: &#39;555555555&#39;})&#10;Call 2 (role only) -&gt; request call: call(&lt;Method.POST: &#39;POST&#39;&gt;, &#39;5YJXCAE43LF123456/roles&#39;, json={&#39;role&#39;: &#39;CHARGING&#39;})&#10;Call 3 (role+federation_id) -&gt; request call: call(&lt;Method.POST: &#39;POST&#39;&gt;, &#39;5YJXCAE43LF123456/roles&#39;, json={&#39;role&#39;: &#39;SUBSCRIPTION&#39;, &#39;federation_id&#39;: &#39;fed-123&#39;})</code>

```text
Call 1 (role+account_id) -> response: {'result': True}
Call 1 -> request call: call(<Method.POST: 'POST'>, '5YJXCAE43LF123456/roles', json={'role': 'SUBSCRIPTION', 'account_id': '555555555'})
Call 2 (role only) -> response: {'result': True}
Call 2 -> request call: call(<Method.POST: 'POST'>, '5YJXCAE43LF123456/roles', json={'role': 'CHARGING'})
Call 3 (role+federation_id) -> response: {'result': True}
Call 3 -> request call: call(<Method.POST: 'POST'>, '5YJXCAE43LF123456/roles', json={'role': 'SUBSCRIPTION', 'federation_id': 'fed-123'})
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest tests/test_tessie_vehicle_params.py -v` — all 7 tests pass (7 passed, 8 subtests), including the two new set_roles tests: test_set_roles_uses_documented_parameters and test_set_roles_omits_unset_optional_fields</code>
- <code>`grep -rn &#34;def set_roles&#34; tesla_fleet_api/` — confirmed set_roles is defined only on TessieVehicle, no collision with VehicleFleet or other backends</code>
- `Manual scripted call to TessieVehicle.set_roles() with a mocked _request across three argument combinations (role+account_id, role only, role+federation_id) — verified the exact POST /{vin}/roles JSON body sent in each case, confirming optional fields are correctly omitted when None`

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
