### PR TITLE
Bump version to 1.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.9.0"
+version = "1.10.0"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.9.0"
+__version__ = "1.10.0"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.tariff import (

--- a/uv.lock
+++ b/uv.lock
@@ -740,7 +740,7 @@ wheels = [
 
 [[package]]
 name = "tesla-fleet-api"
-version = "1.9.0"
+version = "1.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
Bump version to 1.10.0 (minor) for PR #123, which added Tessie's `set_roles` command, and PR #124, which added Teslemetry's `navigation_waypoints_request` and 37 `custom_command` routes (including 5 renames to align with BLE `Commands` method names — those renamed methods were never released, so this is not a breaking change).

Full validation pipeline is skipped per the standing small-change rule for bump-only diffs; ruff, pyright, and pytest were run locally and pass.
