### PR TITLE
fix(teslemetry): remove dangerous parental_controls_clear_pin methods

### DIFF
--- a/tesla_fleet_api/teslemetry/vehicle.py
+++ b/tesla_fleet_api/teslemetry/vehicle.py
@@ -530,21 +530,6 @@ class TeslemetryVehicle(VehicleFleet["Teslemetry"]):
             json={"activate": activate, "pin": pin},
         )
 
-    async def parental_controls_clear_pin(self, pin: str) -> dict[str, Any]:
-        """Clears the parental controls PIN."""
-        return await self._request(
-            Method.POST,
-            f"api/1/vehicles/{self.vin}/custom_command/parental_controls_clear_pin",
-            json={"pin": pin},
-        )
-
-    async def parental_controls_clear_pin_admin(self) -> dict[str, Any]:
-        """Clears the parental controls PIN as admin (fleet manager/owner)."""
-        return await self._request(
-            Method.POST,
-            f"api/1/vehicles/{self.vin}/custom_command/parental_controls_clear_pin_admin",
-        )
-
     async def parental_controls_enable_setting(
         self, setting: int, enable: bool
     ) -> dict[str, Any]:

--- a/tests/test_teslemetry_vehicle_custom_commands.py
+++ b/tests/test_teslemetry_vehicle_custom_commands.py
@@ -275,23 +275,6 @@ class CustomCommandRequestShapeTests(IsolatedAsyncioTestCase):
             json={"activate": True, "pin": "1234"},
         )
 
-    async def test_parental_controls_clear_pin(self) -> None:
-        vehicle, request = _make_vehicle()
-        await vehicle.parental_controls_clear_pin("1234")
-        request.assert_awaited_once_with(
-            Method.POST,
-            f"api/1/vehicles/{VIN}/custom_command/parental_controls_clear_pin",
-            json={"pin": "1234"},
-        )
-
-    async def test_parental_controls_clear_pin_admin(self) -> None:
-        vehicle, request = _make_vehicle()
-        await vehicle.parental_controls_clear_pin_admin()
-        request.assert_awaited_once_with(
-            Method.POST,
-            f"api/1/vehicles/{VIN}/custom_command/parental_controls_clear_pin_admin",
-        )
-
     async def test_parental_controls_enable_setting(self) -> None:
         vehicle, request = _make_vehicle()
         await vehicle.parental_controls_enable_setting(1, True)


### PR DESCRIPTION
## Intent

Remove parental_controls_clear_pin and parental_controls_clear_pin_admin from the Teslemetry class (tesla_fleet_api/teslemetry/vehicle.py), added in the 1.10.0 parity uplift (PR #124), plus their tests in tests/test_teslemetry_vehicle_custom_commands.py. These two custom_command routes stay hidden/dangerous per the captain-confirmed classification in api PR https://github.com/Teslemetry/api/pull/425 (merged 2026-08-15): they erase a stored parental-control safety PIN, the same credential-erasure class as the already-public remove_key, and the served OpenAPI spec keeps them hidden. Library and public spec must agree: hidden routes get no published client methods. Verified against PR 425's full 42-route verdict table that these are the ONLY library-published-but-spec-hidden methods in the 'dangerous' class - the other 6 routes PR 425 kept hidden (set_discharge_limit, set_outlet_timer, set_power_feed_timer, batch_remove_charge_schedules, batch_remove_precondition_schedules, drivenote) have no published tesla-fleet-api 1.10.0 method at all, so nothing to remove for those. Note: tesla_fleet_api/tesla/vehicle/commands.py (the BLE/signed-command protocol implementation, a separate class predating 1.10.0 since March 2026) also defines methods with these same names - out of scope, not touched, since the task and PR 425 concern the Teslemetry REST custom_command routes specifically, not the BLE vehicle-command protocol. Nothing else changes in this PR - no version bump (bump-only PRs are shipped separately per standing repo rule). PR body must state a one-line rationale per removal pointing at the served-spec policy from PR 425.

## What Changed

- Removed `TeslemetryVehicle.parental_controls_clear_pin` and `parental_controls_clear_pin_admin` from `tesla_fleet_api/teslemetry/vehicle.py`. Both routes erase a stored parental-control safety PIN (the same credential-erasure class as the already-public `remove_key`) and were confirmed hidden in Teslemetry's served OpenAPI spec per [api PR #425](https://github.com/Teslemetry/api/pull/425) — the library must not publish client methods for routes the spec keeps hidden.
- Removed the corresponding request-shape tests (`test_parental_controls_clear_pin`, `test_parental_controls_clear_pin_admin`) from `tests/test_teslemetry_vehicle_custom_commands.py`.
- The BLE/signed-command implementation in `tesla_fleet_api/tesla/vehicle/commands.py`, which predates this REST addition and defines methods of the same name, is intentionally untouched — it's a separate protocol surface outside PR #425's scope.

## Risk Assessment

✅ Low: The change is a minimal, precisely-scoped deletion (two methods and their tests) that exactly matches the stated intent, leaves the unrelated BLE commands.py implementation untouched as required, includes no version bump, and leaves no dangling references to the removed methods anywhere in the codebase.

## Testing

Ran the targeted test module for Teslemetry custom-command routes (all 36 pass) and manually confirmed via attribute introspection that TeslemetryVehicle no longer exposes parental_controls_clear_pin/_admin while sibling parental-controls methods remain intact; grep confirmed no other file references the removed methods except the correctly out-of-scope BLE commands.py, and no version bump was included in the diff.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest tests/test_teslemetry_vehicle_custom_commands.py -v` — all 36 tests pass, confirming remaining parental-controls/custom-command routes still build correct requests after the removal</code>
- <code>`grep -rn &#34;parental_controls_clear_pin&#34; --include=&#34;*.py&#34; --include=&#34;*.md&#34; .` — confirmed the only remaining references are in tesla_fleet_api/tesla/vehicle/commands.py (the separate, intentionally out-of-scope BLE/signed-command implementation)</code>
- <code>Manual attribute check: `hasattr(TeslemetryVehicle, &#39;parental_controls_clear_pin&#39;)` / `_admin` both False post-change, while a sibling method (`parental_controls_enable_setting`) remains True — confirms the public client surface no longer exposes the two hidden/dangerous routes</code>
- <code>`git diff 719ef8b..bc73c17 -- pyproject.toml tesla_fleet_api/__init__.py` — empty, confirming no version bump was bundled, per the stated standing repo rule</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
