### PR TITLE
Bump version to 1.10.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.10.0"
+version = "1.10.1"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.10.0"
+__version__ = "1.10.1"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.tariff import (


### PR DESCRIPTION
Bump version to 1.10.1 (patch) for PR #127, which fixed dotted-quad IPv4 gateway address decoding with strict validation.

Full validation pipeline is skipped per the standing small-change rule for bump-only diffs; ruff, pyright, and pytest were run locally and pass.
