### PR TITLE
chore: bump version to 1.11.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.10.1"
+version = "1.11.0"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.10.1"
+__version__ = "1.11.0"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.funnel import (

--- a/uv.lock
+++ b/uv.lock
@@ -740,7 +740,7 @@ wheels = [
 
 [[package]]
 name = "tesla-fleet-api"
-version = "1.10.1"
+version = "1.11.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Intent

Cut version 1.11.0 of tesla-fleet-api so ObservationFunnel (landed in PR #131, after the 1.10.1 version bump) becomes installable from PyPI. Pure release task: no library behavior changes, no refactoring, no funnel.py edits. Three commits are unreleased since 1.10.1: the funnel feature (#131), a CI lockfile-drift gate (#129), and a docs correction (#130). New feature, no breaking change, so 1.11.0 is the right bump. Followed the documented release process in AGENTS.md: bumped version in pyproject.toml and __version__ in tesla_fleet_api/__init__.py, ran uv lock to regenerate uv.lock so its root package version matches (CI's uv sync --locked would otherwise fail the build), committed as 'Bump version to 1.11.0'. Verified ObservationFunnel imports cleanly from the public package surface (from tesla_fleet_api import ObservationFunnel). Ran the full release gate locally: ruff check/format, pyright strict, pytest (707 passed), uv build, and twine check on the built sdist/wheel — all clean. Searched the repo for any other version-string occurrences outside pyproject.toml/__init__.py/uv.lock and found none, so no other file needs to move in step. Do not create or push a git tag, do not publish, do not touch the pypi environment or run twine upload — publication is a separate, later action by others after this PR merges.

## What Changed

- Bumped `version` in `pyproject.toml` and `__version__` in `tesla_fleet_api/__init__.py` from `1.10.1` to `1.11.0`.
- Regenerated `uv.lock` via `uv lock` so its root package version matches the bumped `pyproject.toml`, satisfying CI's `uv sync --locked` lockfile-drift gate.
- No source or behavior changes — this makes the `ObservationFunnel` feature (#131), the CI lockfile-drift gate (#129), and the docs correction (#130), all previously merged to `main` since `1.10.1`, installable as a new PyPI release.

## Risk Assessment

✅ Low: The change is a minimal three-line version bump (pyproject.toml, __init__.py, uv.lock) with no library code touched; version strings are consistent across all three files and ObservationFunnel is confirmed exported from the public package surface, matching the stated pure-release intent exactly.

## Testing

Confirmed the 1.11.0 bump commit is exactly the described release-only change (pyproject.toml, __init__.py, uv.lock in lockstep, no other file touched), verified CI's `uv sync --locked` lockfile check passes, ran the funnel test suite (30/30 passed), and end-to-end demonstrated that `from tesla_fleet_api import ObservationFunnel` imports and works at __version__ 1.11.0 — the concrete outcome the release exists to unblock. No tag was created/pushed and no stray version strings exist elsewhere, matching every stated constraint.

<details>
<summary>Evidence: ObservationFunnel importable from public package surface at v1.11.0</summary>

```text
$ uv run python -c "from tesla_fleet_api import ObservationFunnel, __version__; print(__version__); print(ObservationFunnel); f=ObservationFunnel(); print(f.value('Locked'))"
version: 1.11.0
ObservationFunnel: <class 'tesla_fleet_api.funnel.ObservationFunnel'>
value Locked (unobserved): None
```
</details>
<details>
<summary>Evidence: uv sync --locked (CI&#39;s exact lockfile-drift gate)</summary>

```text
+ tesla-fleet-api==1.11.0 (from file:///.../01M0P3PV49AB5JXD44GWFKHYPS)
... (resolved cleanly, no lockfile drift)
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `git diff 49ae54d..HEAD (confirms minimal 3-line version-only diff)`
- `grep for version strings 1.10.1/1.11.0 across .py/.toml/.md/.cfg/.lock files (only the three expected occurrences)`
- <code>`uv sync --locked` (CI&#39;s lockfile-drift gate command)</code>
- <code>`uv run python -c &#34;from tesla_fleet_api import ObservationFunnel, __version__; ...&#34;` (public import surface + version check)</code>
- <code>`uv run pytest tests/test_funnel.py -q` (30 passed)</code>
- <code>`git tag -l | grep 1.11.0` (confirms no tag created)</code>
- <code>`git status --short` before/after, reverting egg-info build artifacts from my own verification</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
