### PR TITLE
fix(ble): guard empty publicKey in session-info authentication

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools>=77.0"]
 
 [project]
 name = "tesla_fleet_api"
-version = "1.11.0"
+version = "1.11.1"
 license = "Apache-2.0"
 description = "Tesla Fleet API library for Python"
 readme = "README.md"

--- a/tesla_fleet_api/__init__.py
+++ b/tesla_fleet_api/__init__.py
@@ -1,7 +1,7 @@
 """Tesla Fleet API"""
 
 __author__ = "hello@teslemetry.com"
-__version__ = "1.11.0"
+__version__ = "1.11.1"
 
 from tesla_fleet_api.const import Region, is_valid_region
 from tesla_fleet_api.funnel import (

--- a/tesla_fleet_api/exceptions.py
+++ b/tesla_fleet_api/exceptions.py
@@ -480,7 +480,11 @@ class SessionInfoAuthenticationFault(TeslaFleetError):
     Raised when the reply's ``session_info_tag`` HMAC does not verify, is
     absent, the echoed ``request_uuid`` does not match the outstanding
     request it claims to answer, or its clock time regresses within the same
-    epoch. The session's prior state is left unmodified.
+    epoch. Also raised when the reply carries an empty ``publicKey`` (so no
+    shared key can be derived to verify a tag) with a status other than
+    ``SESSION_INFO_STATUS_KEY_NOT_ON_WHITELIST``, which raises
+    ``NotOnWhitelistFault`` instead. The session's prior state is left
+    unmodified.
     """
 
     message = "Session info reply failed authentication and was discarded."

--- a/tesla_fleet_api/tesla/vehicle/commands.py
+++ b/tesla_fleet_api/tesla/vehicle/commands.py
@@ -544,7 +544,12 @@ class Commands(ABC, Vehicle[CommandParentT], Generic[CommandParentT]):
         replayed against a newer request. Only once that tag checks out do we
         act on anything the message claims, including its own whitelist
         status, and even then ``Session.commit`` still refuses a clock time
-        that regresses within the same epoch.
+        that regresses within the same epoch. The one exception is an empty
+        public key: no shared key can be derived from it to verify a tag, so
+        a key-not-on-whitelist status - the only real-world reply that omits
+        the key, since no session exists yet for an unpaired key - is
+        accepted unauthenticated; any other status paired with an empty key
+        is malformed and rejected outright.
 
         VCSEC typically leaves the wire-level ``request_uuid`` field empty on
         real hardware (memory constraints) - its absence must never be
@@ -558,6 +563,22 @@ class Commands(ABC, Vehicle[CommandParentT], Generic[CommandParentT]):
 
         session = self._sessions[msg.from_destination.domain]
         info = SessionInfo.FromString(msg.session_info)
+
+        # A key-not-on-whitelist reply carries no publicKey (no session exists
+        # for an unpaired key), so it cannot be HMAC-verified; accept that one
+        # status unauthenticated rather than deriving keys from an empty
+        # point. Any other status with an empty key is malformed, not this
+        # known case, so it still raises rather than being silently accepted.
+        if not info.publicKey:
+            if (
+                info.status
+                == Session_Info_Status.SESSION_INFO_STATUS_KEY_NOT_ON_WHITELIST
+            ):
+                raise NotOnWhitelistFault
+            raise SessionInfoAuthenticationFault(
+                "Session info reply has no public key."
+            )
+
         shared_key, hmac_key, session_info_key = session.keys_for(info.publicKey)
 
         tag = msg.signature_data.session_info_tag.tag

--- a/tests/test_session_info_authentication.py
+++ b/tests/test_session_info_authentication.py
@@ -338,6 +338,45 @@ class SessionInfoTagAuthenticationTests(IsolatedAsyncioTestCase):
             self.commands.validate_msg(reply, self.request_uuid)
         self.assertFalse(self.commands._sessions[self.domain].ready)
 
+    def test_empty_public_key_whitelist_rejection_raises_not_on_whitelist(self) -> None:
+        # Real-world VCSEC reply for an unpaired key: no session exists to
+        # derive a shared key from, so publicKey is empty. Must not attempt
+        # key derivation (which previously raised a raw ValueError) and must
+        # still surface as NotOnWhitelistFault, unauthenticated.
+        info = self._session_info(
+            publicKey=b"",
+            status=Session_Info_Status.SESSION_INFO_STATUS_KEY_NOT_ON_WHITELIST,
+        )
+        signature_data = SignatureData(
+            session_info_tag=HMAC_Signature_Data(tag=b"\x00" * 32)
+        )
+        reply = RoutableMessage(
+            from_destination=Destination(domain=self.domain),
+            session_info=info.SerializeToString(),
+            request_uuid=self.request_uuid,
+            signature_data=signature_data,
+        )
+        with self.assertRaises(NotOnWhitelistFault):
+            self.commands.validate_msg(reply, self.request_uuid)
+        self.assertFalse(self.commands._sessions[self.domain].ready)
+
+    def test_empty_public_key_with_other_status_raises_typed_fault(self) -> None:
+        info = self._session_info(
+            publicKey=b"", status=Session_Info_Status.SESSION_INFO_STATUS_OK
+        )
+        signature_data = SignatureData(
+            session_info_tag=HMAC_Signature_Data(tag=b"\x00" * 32)
+        )
+        reply = RoutableMessage(
+            from_destination=Destination(domain=self.domain),
+            session_info=info.SerializeToString(),
+            request_uuid=self.request_uuid,
+            signature_data=signature_data,
+        )
+        with self.assertRaises(SessionInfoAuthenticationFault):
+            self.commands.validate_msg(reply, self.request_uuid)
+        self.assertFalse(self.commands._sessions[self.domain].ready)
+
 
 class CounterAndClockMonotonicityTests(IsolatedAsyncioTestCase):
     """Covers commands.py's Session.commit: clamp within an epoch, refuse a

--- a/uv.lock
+++ b/uv.lock
@@ -740,7 +740,7 @@ wheels = [
 
 [[package]]
 name = "tesla-fleet-api"
-version = "1.11.0"
+version = "1.11.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Intent

Fix a BLE pairing crash: when the vehicle replies to the VEHICLE_SECURITY handshake with SESSION_INFO_STATUS_KEY_NOT_ON_WHITELIST, _authenticate_session_info in tesla_fleet_api/tesla/vehicle/commands.py previously called session.keys_for(info.publicKey) before checking info.status. A key-not-on-whitelist reply carries an empty publicKey (no session exists yet for an unpaired key), so key derivation raised an uncaught ValueError: data must not be an empty byte string instead of the intended NotOnWhitelistFault. This made the Home Assistant approve-key-in-vehicle pairing flow crash instead of prompting the user, blocking all first-time BLE pairing. Fix: added an empty-publicKey guard before key derivation - when publicKey is empty and status is KEY_NOT_ON_WHITELIST, raise NotOnWhitelistFault unauthenticated (no shared key can be derived to verify a tag in this case, matching Tesla's own vehicle-command client behavior); when publicKey is empty with any other status, raise a typed SessionInfoAuthenticationFault instead of letting the raw ValueError escape. The existing tag-verified-before-whitelist-trust behavior is preserved for the case where publicKey is non-empty (an existing test locks that in), so the fix is a narrow reorder plus one guard, not a restructuring of the session machinery. Added two new tests covering the empty-publicKey cases in tests/test_session_info_authentication.py. Version bumped 1.11.0 -> 1.11.1 (patch, bug fix) per repo release convention, with uv lock re-run to keep uv.lock in sync.

## What Changed

- `_authenticate_session_info` (`tesla_fleet_api/tesla/vehicle/commands.py`) now checks `info.publicKey` before calling `session.keys_for(...)`: an empty key with `SESSION_INFO_STATUS_KEY_NOT_ON_WHITELIST` raises `NotOnWhitelistFault` unauthenticated (no shared key can be derived to verify a tag in this case), while an empty key with any other status raises `SessionInfoAuthenticationFault` instead of letting a raw `ValueError` escape from key derivation. The existing tag-verified-before-whitelist-trust behavior for non-empty `publicKey` replies is unchanged.
- `SessionInfoAuthenticationFault`'s docstring (`tesla_fleet_api/exceptions.py`) documents the new empty-publicKey/non-whitelist-status case.
- Added `tests/test_session_info_authentication.py` coverage for the two new empty-publicKey cases.
- Bumped version 1.11.0 → 1.11.1 (`pyproject.toml`, `tesla_fleet_api/__init__.py`) with `uv.lock` regenerated to match.

## Risk Assessment

✅ Low: Narrow, well-contained fix: an empty-publicKey guard is added before key derivation in _authenticate_session_info, raising NotOnWhitelistFault for the documented KEY_NOT_ON_WHITELIST case and a typed SessionInfoAuthenticationFault otherwise, exactly matching the stated intent; the existing tag-verified-before-whitelist-trust path for non-empty publicKey is untouched, two new tests exercise real behavior (exception type and session.ready state) rather than source text, and the version bump/uv.lock are consistent.

## Testing

Ran the targeted session-info authentication test suite on the target commit (25/25 pass) and separately reproduced the pre-fix failure by running the same new tests against the base commit in a scratch worktree, where they fail with the exact ValueError described in the intent — this is a genuine regression test proving the crash is fixed, not just new tests that happen to pass. Version/lockfile bump also verified consistent. No issues found; scratch worktree used for the base-commit repro was removed afterward and the working tree is clean.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"76f45b4756fbfe1f6444984e5c08e59b8877f720","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest tests/test_session_info_authentication.py -v` on target commit 50d51c3 — all 25 tests pass, including the two new empty-publicKey cases</code>
- <code>Reproduced the pre-fix crash: checked out base commit f1822c8 into a scratch worktree, copied the target&#39;s new test file in, ran `uv run pytest tests/test_session_info_authentication.py -k empty_public_key -v` — both new tests fail with the exact reported `ValueError: data must not be an empty byte string` raised from `EllipticCurvePublicKey.from_encoded_point`, confirming the tests genuinely exercise the reported bug and the fix resolves it</code>
- `Confirmed version bump 1.11.0 -> 1.11.1 is reflected consistently in pyproject.toml, tesla_fleet_api/__init__.py, and uv.lock per repo release convention`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
