### PR TITLE
fix(typing): add -> None to __init__ methods missing return annotation

### DIFF
--- a/tesla_fleet_api/exceptions.py
+++ b/tesla_fleet_api/exceptions.py
@@ -15,7 +15,7 @@ class TeslaFleetError(BaseException):
 
     def __init__(
         self, data: dict[str, Any] | str | None = None, status: int | None = None
-    ):
+    ) -> None:
         LOGGER.debug(self.message)
         self.data = data
         self.status = status or self.status

--- a/tesla_fleet_api/router/base.py
+++ b/tesla_fleet_api/router/base.py
@@ -111,7 +111,7 @@ class Router(Generic[PrimaryT, SecondaryT]):
         secondary: SecondaryT,
         *more_backends: Any,
         health: HealthCheck | None = None,
-    ):
+    ) -> None:
         # The two-argument ``Router(primary, secondary, health=...)`` form is
         # preserved exactly; additional positional backends extend the chain.
         self._backends = (primary, secondary, *more_backends)

--- a/tesla_fleet_api/tesla/bluetooth.py
+++ b/tesla_fleet_api/tesla/bluetooth.py
@@ -23,7 +23,7 @@ class TeslaBluetooth(Tesla):
 
     def __init__(
         self,
-    ):
+    ) -> None:
         """Initialize the Tesla Fleet API."""
 
         self.vehicles = self.Vehicles(self)

--- a/tesla_fleet_api/tesla/charging.py
+++ b/tesla_fleet_api/tesla/charging.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 class Charging:
     """Class describing the Tesla Fleet API charging endpoints."""
 
-    def __init__(self, parent: "TeslaFleetApi"):
+    def __init__(self, parent: "TeslaFleetApi") -> None:
         self._request = parent._request  # pyright: ignore[reportPrivateUsage]
 
     async def history(

--- a/tesla_fleet_api/tesla/energysite.py
+++ b/tesla_fleet_api/tesla/energysite.py
@@ -24,7 +24,7 @@ class EnergySite:
 
     energy_site_id: int
 
-    def __init__(self, parent: TeslaFleetApi, energy_site_id: int):
+    def __init__(self, parent: TeslaFleetApi, energy_site_id: int) -> None:
         self._request = parent._request  # pyright: ignore[reportPrivateUsage]
         self.energy_site_id = energy_site_id
 
@@ -424,7 +424,7 @@ class EnergySites(dict[int, EnergySite]):
     _parent: TeslaFleetApi
     Site = EnergySite
 
-    def __init__(self, parent: TeslaFleetApi):
+    def __init__(self, parent: TeslaFleetApi) -> None:
         self._parent = parent
 
     def create(self, energy_site_id: int) -> EnergySite:

--- a/tesla_fleet_api/tesla/fleet.py
+++ b/tesla_fleet_api/tesla/fleet.py
@@ -85,7 +85,7 @@ class TeslaFleetApi(Tesla):
         partner_scope: bool = True,
         user_scope: bool = True,
         vehicle_scope: bool = True,
-    ):
+    ) -> None:
         """Initialize the Tesla Fleet API."""
 
         self.session = session or aiohttp.ClientSession()

--- a/tesla_fleet_api/tesla/oauth.py
+++ b/tesla_fleet_api/tesla/oauth.py
@@ -27,7 +27,7 @@ class TeslaFleetOAuth(TeslaFleetApi):
         access_token: str | None = None,
         refresh_token: str | None = None,
         expires: int = 0,
-    ):
+    ) -> None:
         if not is_valid_region(region):
             raise ValueError("Invalid region")
 

--- a/tesla_fleet_api/tesla/partner.py
+++ b/tesla_fleet_api/tesla/partner.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 class Partner:
     """Class describing the Tesla Fleet API partner endpoints"""
 
-    def __init__(self, parent: "TeslaFleetApi"):
+    def __init__(self, parent: "TeslaFleetApi") -> None:
         self._request = parent._request  # pyright: ignore[reportPrivateUsage]
 
     async def public_key(self, domain: str | None = None) -> dict[str, Any]:

--- a/tesla_fleet_api/tesla/user.py
+++ b/tesla_fleet_api/tesla/user.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 class User:
     """Class describing the Tesla Fleet API user endpoints"""
 
-    def __init__(self, parent: "TeslaFleetApi"):
+    def __init__(self, parent: "TeslaFleetApi") -> None:
         self._request = parent._request  # pyright: ignore[reportPrivateUsage]
 
     async def backup_key(self) -> dict[str, Any]:

--- a/tesla_fleet_api/tesla/vehicle/bluetooth.py
+++ b/tesla_fleet_api/tesla/vehicle/bluetooth.py
@@ -161,7 +161,7 @@ class ReassemblingBuffer:
     the next chunk doesn't arrive within ``STALE_CHUNK_TIMEOUT``.
     """
 
-    def __init__(self, callback: Callable[[RoutableMessage], None]):
+    def __init__(self, callback: Callable[[RoutableMessage], None]) -> None:
         """
         Initializes the buffer.
 
@@ -529,7 +529,7 @@ class VehicleBluetooth(
         raise_unconfirmed: bool = False,
         *,
         verify_commands: bool | None = None,
-    ):
+    ) -> None:
         """Initialize a BLE-connected vehicle.
 
         ``verify_commands`` and ``optimistic`` are deprecated aliases for

--- a/tesla_fleet_api/tesla/vehicle/commands.py
+++ b/tesla_fleet_api/tesla/vehicle/commands.py
@@ -317,7 +317,7 @@ class Session(Generic[CommandParentT]):
 
     _response_counter_cache_size = 256
 
-    def __init__(self, parent: Commands[CommandParentT], domain: Domain):
+    def __init__(self, parent: Commands[CommandParentT], domain: Domain) -> None:
         self.parent: Commands[CommandParentT] = parent
         self.domain: Domain = domain
         self.counter: int = 0
@@ -443,7 +443,7 @@ class Commands(ABC, Vehicle[CommandParentT], Generic[CommandParentT]):
         vin: str,
         private_key: ec.EllipticCurvePrivateKey | Literal[False] | None = None,
         public_key: bytes | None = None,
-    ):
+    ) -> None:
         """Initialize with a signing key, or ``private_key=False`` to disable signing.
 
         ``None`` (the default, and an explicit ``None``) keeps the long-standing

--- a/tesla_fleet_api/tesla/vehicle/fleet.py
+++ b/tesla_fleet_api/tesla/vehicle/fleet.py
@@ -29,7 +29,7 @@ FleetParentT = TypeVar("FleetParentT", bound="TeslaFleetApi")
 class VehicleFleet(Vehicle[FleetParentT], Generic[FleetParentT]):
     """Class describing the Tesla Fleet API vehicle endpoints and commands."""
 
-    def __init__(self, parent: FleetParentT, vin: str):
+    def __init__(self, parent: FleetParentT, vin: str) -> None:
         super().__init__(parent, vin)
         self._request = parent._request  # pyright: ignore[reportPrivateUsage]
 

--- a/tesla_fleet_api/tesla/vehicle/signed.py
+++ b/tesla_fleet_api/tesla/vehicle/signed.py
@@ -23,7 +23,7 @@ class VehicleSigned(  # pyright: ignore[reportIncompatibleMethodOverride]
     _auth_method = "hmac"
     _transport_name = "fleet"
 
-    def __init__(self, parent: SignedParentT, vin: str):
+    def __init__(self, parent: SignedParentT, vin: str) -> None:
         """Initialize the VehicleSigned class."""
         super().__init__(parent, vin)
         super(Commands, self).__init__(parent, vin)

--- a/tesla_fleet_api/tesla/vehicle/vehicle.py
+++ b/tesla_fleet_api/tesla/vehicle/vehicle.py
@@ -25,7 +25,7 @@ class Vehicle(Generic[ParentT]):
     vin: str
     parent: ParentT
 
-    def __init__(self, parent: ParentT, vin: str):
+    def __init__(self, parent: ParentT, vin: str) -> None:
         self.vin = vin
         self.parent = parent
 

--- a/tesla_fleet_api/tesla/vehicle/vehicles.py
+++ b/tesla_fleet_api/tesla/vehicle/vehicles.py
@@ -29,7 +29,7 @@ class Vehicles(dict[str, Vehicle[Any]], Generic[FleetParentT]):
     Signed: type[VehicleSigned[FleetParentT]] = VehicleSigned
     Bluetooth: type[VehicleBluetooth[FleetParentT]] = VehicleBluetooth
 
-    def __init__(self, parent: FleetParentT):
+    def __init__(self, parent: FleetParentT) -> None:
         self._parent = parent
 
     def createFleet(self, vin: str) -> VehicleFleet[FleetParentT]:
@@ -99,7 +99,7 @@ class VehiclesBluetooth(dict[str, Vehicle[Any]], Generic[BluetoothClientT]):
     _parent: BluetoothClientT
     Bluetooth: type[VehicleBluetooth[BluetoothClientT]] = VehicleBluetooth
 
-    def __init__(self, parent: BluetoothClientT):
+    def __init__(self, parent: BluetoothClientT) -> None:
         self._parent = parent
 
     def create(

--- a/tesla_fleet_api/teslemetry/teslemetry.py
+++ b/tesla_fleet_api/teslemetry/teslemetry.py
@@ -102,7 +102,7 @@ class Teslemetry(TeslaFleetApi):
         session: aiohttp.ClientSession,
         access_token: str | Callable[[], Awaitable[str | None]],
         server: str = "https://api.teslemetry.com",
-    ):
+    ) -> None:
         """Initialize the Teslemetry API."""
 
         self.session = session

--- a/tesla_fleet_api/tessie/tessie.py
+++ b/tesla_fleet_api/tessie/tessie.py
@@ -19,7 +19,7 @@ class Tessie(TeslaFleetApi):
         access_token: str,
         wait_for_completion: bool = True,
         max_attempts: int = 3,
-    ):
+    ) -> None:
         """Initialize the Tessie API."""
 
         self.session = session


### PR DESCRIPTION
Missing return annotations on `__init__` methods (e.g. `TeslaBluetooth.__init__`) make mypy treat every call site as an untyped call in downstream consumers (the Home Assistant integration), forcing a `# type: ignore[no-untyped-call]` there even though the library is fully typed otherwise. Adds `-> None` to every `__init__` in the package missing it.

Annotation-only change; no behavior change. `ruff`, `pyright`, and the test suite pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VvadPv5MzPinGHF9WXJK6c
