### PR TITLE
feat(router): add local-Powerwall key-ownership merge contract

### DIFF
--- a/docs/energy_local_control.md
+++ b/docs/energy_local_control.md
@@ -266,6 +266,39 @@ and the `health` check).
 > status read (for example `live_status()`'s grid/island fields) before
 > trusting the response for anything actuation-critical.
 
+### Merge contract
+
+`EnergySiteRouter`'s per-command dispatch is **not** a merge - calling
+`router.live_status()` returns one whole source's response (local, or cloud on
+failover), not a blend of both. `PowerwallEnergySite.live_status()` reports all
+of the cloud response's keys but fills in `None` for the ones it cannot serve
+locally, so a consumer that wants "local readings where available, cloud
+otherwise" needs to merge the two responses itself, field by field.
+
+`tesla_fleet_api.router.energysite` provides that merge as a plain function,
+independent of `Router`:
+
+```python
+from tesla_fleet_api.router.energysite import (
+    LOCAL_LIVE_STATUS_KEYS,
+    LOCAL_SITE_INFO_KEYS,
+    merge_local_into_cloud,
+)
+
+cloud_status = await teslemetry_energysite.live_status()
+local_status = await local_energysite.live_status()
+merged = merge_local_into_cloud(cloud_status, local_status, LOCAL_LIVE_STATUS_KEYS)
+```
+
+- `LOCAL_LIVE_STATUS_KEYS` are the `live_status()` fields the local gateway can
+  actually serve; `LOCAL_SITE_INFO_KEYS` are the `site_info()` equivalent
+  (`backup_reserve_percent`, `default_real_mode`).
+- Only keys in the given set **and** present in `local` are overlaid onto a
+  copy of `cloud`; every other key keeps its cloud value.
+- If the local read failed entirely (`local is None`, e.g. the LAN call
+  raised), the result is just `cloud` - the same fallback-to-cloud behavior
+  `Router` gives non-merged commands.
+
 ## See also
 
 - [Fleet API for Energy Sites](fleet_api_energy_sites.md) - the cloud

--- a/tesla_fleet_api/router/__init__.py
+++ b/tesla_fleet_api/router/__init__.py
@@ -2,11 +2,19 @@
 
 from tesla_fleet_api.router.base import HealthCheck, Router
 from tesla_fleet_api.router.vehicle import VehicleRouter
-from tesla_fleet_api.router.energysite import EnergySiteRouter
+from tesla_fleet_api.router.energysite import (
+    EnergySiteRouter,
+    LOCAL_LIVE_STATUS_KEYS,
+    LOCAL_SITE_INFO_KEYS,
+    merge_local_into_cloud,
+)
 
 __all__ = [
     "Router",
     "VehicleRouter",
     "EnergySiteRouter",
     "HealthCheck",
+    "LOCAL_LIVE_STATUS_KEYS",
+    "LOCAL_SITE_INFO_KEYS",
+    "merge_local_into_cloud",
 ]

--- a/tesla_fleet_api/router/energysite.py
+++ b/tesla_fleet_api/router/energysite.py
@@ -1,6 +1,46 @@
 from __future__ import annotations
 
+from typing import Any
+
 from tesla_fleet_api.router.base import PrimaryT, Router, SecondaryT
+
+LOCAL_LIVE_STATUS_KEYS: frozenset[str] = frozenset(
+    {
+        "solar_power",
+        "energy_left",
+        "total_pack_energy",
+        "percentage_charged",
+        "battery_power",
+        "load_power",
+        "grid_power",
+        "generator_power",
+        "grid_status",
+        "island_status",
+    }
+)
+LOCAL_SITE_INFO_KEYS: frozenset[str] = frozenset(
+    {"backup_reserve_percent", "default_real_mode"}
+)
+
+
+def merge_local_into_cloud(
+    cloud: dict[str, Any], local: dict[str, Any] | None, owned_keys: frozenset[str]
+) -> dict[str, Any]:
+    """Overlay owned_keys present in local onto a copy of cloud; every other key keeps its cloud value.
+
+    ``PowerwallEnergySite.live_status()`` returns all cloud keys with ``None``
+    for the ones it cannot serve, so presence-in-response cannot be the
+    ownership test — a fixed owned-key set lets a caller overlay local
+    readings without clobbering cloud values, and lets a local outage fall
+    back to the cloud value instead of an unavailable one.
+    """
+    merged = dict(cloud)
+    if local is None:
+        return merged
+    for key in owned_keys:
+        if key in local:
+            merged[key] = local[key]
+    return merged
 
 
 class EnergySiteRouter(Router[PrimaryT, SecondaryT]):

--- a/tesla_fleet_api/tesla/__init__.py
+++ b/tesla_fleet_api/tesla/__init__.py
@@ -6,7 +6,14 @@ from tesla_fleet_api.tesla.oauth import TeslaFleetOAuth
 from tesla_fleet_api.tesla.charging import Charging
 from tesla_fleet_api.tesla.energysite import EnergySites, EnergySite
 from tesla_fleet_api.tesla.partner import Partner
-from tesla_fleet_api.router import Router, VehicleRouter, EnergySiteRouter
+from tesla_fleet_api.router import (
+    Router,
+    VehicleRouter,
+    EnergySiteRouter,
+    LOCAL_LIVE_STATUS_KEYS,
+    LOCAL_SITE_INFO_KEYS,
+    merge_local_into_cloud,
+)
 from tesla_fleet_api.tesla.user import User
 from tesla_fleet_api.tesla.vehicle import (
     Vehicles,
@@ -35,4 +42,7 @@ __all__ = [
     "VehicleBluetooth",
     "Router",
     "VehicleRouter",
+    "LOCAL_LIVE_STATUS_KEYS",
+    "LOCAL_SITE_INFO_KEYS",
+    "merge_local_into_cloud",
 ]

--- a/tests/test_energysite_merge_contract.py
+++ b/tests/test_energysite_merge_contract.py
@@ -1,0 +1,71 @@
+"""Unit tests for the local-Powerwall key-ownership merge contract.
+
+`merge_local_into_cloud` is a plain function, independent of `Router`
+dispatch - see docs/energy_local_control.md's "Merge contract" section.
+"""
+
+import unittest
+
+from tesla_fleet_api.router import (
+    LOCAL_LIVE_STATUS_KEYS,
+    LOCAL_SITE_INFO_KEYS,
+    merge_local_into_cloud,
+)
+
+
+class TestMergeLocalIntoCloud(unittest.TestCase):
+    def test_local_none_returns_cloud_values(self) -> None:
+        cloud = {"solar_power": 100, "grid_power": 50, "generator_power": 0}
+        result = merge_local_into_cloud(cloud, None, LOCAL_LIVE_STATUS_KEYS)
+        self.assertEqual(result, cloud)
+
+    def test_owned_key_present_in_local_is_overlaid(self) -> None:
+        cloud = {"solar_power": 100, "grid_power": 50}
+        local = {"solar_power": 200}
+        result = merge_local_into_cloud(cloud, local, LOCAL_LIVE_STATUS_KEYS)
+        self.assertEqual(result["solar_power"], 200)
+        self.assertEqual(result["grid_power"], 50)
+
+    def test_owned_key_absent_from_local_keeps_cloud_value(self) -> None:
+        cloud = {"solar_power": 100, "grid_power": 50}
+        local: dict = {"solar_power": 200}
+        result = merge_local_into_cloud(cloud, local, LOCAL_LIVE_STATUS_KEYS)
+        self.assertEqual(result["grid_power"], 50)
+
+    def test_falsy_but_present_local_value_is_overlaid(self) -> None:
+        cloud = {"grid_power": 999}
+        local = {"grid_power": 0}
+        result = merge_local_into_cloud(cloud, local, LOCAL_LIVE_STATUS_KEYS)
+        self.assertEqual(result["grid_power"], 0)
+
+    def test_local_keys_outside_owned_set_are_ignored(self) -> None:
+        cloud = {"solar_power": 100}
+        local = {"solar_power": 200, "some_unowned_field": "surprise"}
+        result = merge_local_into_cloud(cloud, local, LOCAL_LIVE_STATUS_KEYS)
+        self.assertNotIn("some_unowned_field", result)
+
+    def test_does_not_mutate_inputs(self) -> None:
+        cloud = {"solar_power": 100}
+        local = {"solar_power": 200}
+        cloud_copy = dict(cloud)
+        local_copy = dict(local)
+        result = merge_local_into_cloud(cloud, local, LOCAL_LIVE_STATUS_KEYS)
+        self.assertEqual(cloud, cloud_copy)
+        self.assertEqual(local, local_copy)
+        self.assertIsNot(result, cloud)
+
+    def test_returns_new_dict_when_local_is_none(self) -> None:
+        cloud = {"solar_power": 100}
+        result = merge_local_into_cloud(cloud, None, LOCAL_LIVE_STATUS_KEYS)
+        self.assertIsNot(result, cloud)
+
+    def test_site_info_keys(self) -> None:
+        cloud = {"backup_reserve_percent": 20, "default_real_mode": "self_consumption"}
+        local = {"backup_reserve_percent": 30}
+        result = merge_local_into_cloud(cloud, local, LOCAL_SITE_INFO_KEYS)
+        self.assertEqual(result["backup_reserve_percent"], 30)
+        self.assertEqual(result["default_real_mode"], "self_consumption")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Intent

Add the local-Powerwall key-ownership contract to tesla-fleet-api, in tesla_fleet_api/router/energysite.py (energy-specific; router/base.py stays entity-agnostic). Define LOCAL_LIVE_STATUS_KEYS (solar_power, energy_left, total_pack_energy, percentage_charged, battery_power, load_power, grid_power, generator_power, grid_status, island_status) and LOCAL_SITE_INFO_KEYS (backup_reserve_percent, default_real_mode) as frozensets, plus merge_local_into_cloud(cloud, local, owned_keys) -> dict that overlays owned_keys present in local onto a copy of cloud; every other key keeps its cloud value. Exact semantics: returns a NEW dict (never mutates inputs); when local is None the result equals cloud; only keys in owned_keys AND present in local are overlaid; a key in owned_keys absent from local keeps the cloud value; a falsy-but-present local value (e.g. grid_power: 0) IS overlaid; keys in local outside owned_keys are ignored. Export all three from the package's public surface the same way EnergySiteRouter is exported (router/__init__.py and tesla/__init__.py).

Added a short WHY note in the function docstring: PowerwallEnergySite.live_status() returns all 16 cloud keys with None for the 6 it cannot serve, so presence-in-response cannot be the ownership test - a fixed owned-key set lets a consumer overlay local readings without clobbering cloud values, and lets a local outage fall back to cloud values rather than unavailable.

Added a 'Merge contract' subsection to docs/energy_local_control.md next to the EnergySiteRouter walkthrough (section 5), covering the two key sets, the one function, the fallback-to-cloud rule, and that per-command router dispatch is NOT the merge (calling router.live_status() returns one whole source, not a blend).

Added unit tests (tests/test_energysite_merge_contract.py) covering the five semantics above (local=None -> cloud values, owned+present overlaid, owned+absent keeps cloud, falsy-but-present overlaid, unowned local keys ignored) plus no-mutation and new-dict checks.

Deliberately did NOT touch Router dispatch, did NOT add health logic (stays with the consumer), did NOT add new classes. Deliberately did NOT bump the package version: this repo's release history shows version bumps happen as their own dedicated commits/PRs, not bundled into feature PRs, so pyproject.toml/__init__.py/uv.lock are left unchanged and the PR body should say so explicitly.

## What Changed

- Added `LOCAL_LIVE_STATUS_KEYS` and `LOCAL_SITE_INFO_KEYS` frozensets and a `merge_local_into_cloud(cloud, local, owned_keys) -> dict` function in `tesla_fleet_api/router/energysite.py`, which overlays only the owned keys present in `local` onto a copy of `cloud` (returns a new dict, never mutates inputs, falls back to `cloud` for absent/owned-missing keys and when `local is None`, and ignores unowned local keys).
- Exported `LOCAL_LIVE_STATUS_KEYS`, `LOCAL_SITE_INFO_KEYS`, and `merge_local_into_cloud` from `tesla_fleet_api/router/__init__.py` and `tesla_fleet_api/tesla/__init__.py`, following the same public-surface pattern as `EnergySiteRouter`.
- Documented a "Merge contract" subsection in `docs/energy_local_control.md` alongside the `EnergySiteRouter` walkthrough, covering the two key sets, the merge function's fallback-to-cloud behavior, and the distinction from `Router` per-command dispatch (which returns one whole source, not a blend).
- Added `tests/test_energysite_merge_contract.py` covering: `local=None` yields cloud values, owned+present keys are overlaid, owned+absent keys keep cloud values, falsy-but-present local values are overlaid, unowned local keys are ignored, and no mutation of inputs occurs with a new dict returned.

No package version bump is included; per this repo's release process, version bumps ship as their own dedicated commits/PRs, so `pyproject.toml`, `tesla_fleet_api/__init__.py`, and `uv.lock` are unchanged.

## Risk Assessment

✅ Low: Small, additive, well-isolated change (new pure function + two frozensets + exports + docs + tests) matching the stated intent exactly, with no modification to existing Router/dispatch logic or call sites.

## Testing

Ran the new focused unit test suite (8/8 pass) and manually exercised the exported public API end-to-end (import from both tesla_fleet_api.tesla and tesla_fleet_api.router, merge behavior with falsy overlay, unowned-key exclusion, None-fallback, and non-mutation all verified live); confirmed no version-bump files were touched. All acceptance criteria in the user intent are satisfied with no findings.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"24f73c7fb9ecaa09d82a42fea55ceed5af1f4f95","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run pytest tests/test_energysite_merge_contract.py -v` — all 8 tests pass, covering local=None fallback, owned+present overlay, owned+absent keeps cloud, falsy-but-present overlay, unowned-key ignore, no-mutation, new-dict identity, and site_info keys</code>
- <code>Manual end-to-end script importing merge_local_into_cloud/LOCAL_LIVE_STATUS_KEYS from both `tesla_fleet_api.tesla` and `tesla_fleet_api.router` public surfaces, confirming identical function object, correct merge output, cloud-fallback on local=None, and cloud dict left unmutated</code>
- <code>`git diff f4c773c..24f73c7 --stat -- pyproject.toml uv.lock tesla_fleet_api/__init__.py` — confirmed empty, verifying no version-bump files were touched as the intent required</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
