### PR TITLE
feat(tesla): raise PrivateKeyError for unusable existing key files

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,10 +172,14 @@ asyncio.run(main())
 For more detailed examples, see [Bluetooth for Vehicles](docs/bluetooth_vehicles.md).
 
 `get_private_key(path)` loads an existing EC private key or creates a new
-unencrypted PEM key file. Newly created key files are created owner-readable
-and owner-writable only (`0600`) from the start, with no write-then-chmod
-window, and concurrent creators fall back to reading the file that won the
-create race.
+unencrypted PEM key file, and `get_rsa_private_key(path)` does the same for an
+RSA key. Newly created key files are created owner-readable and
+owner-writable only (`0600`) from the start, with no write-then-chmod window,
+and concurrent creators fall back to reading the file that won the create
+race. If an existing key file can't be read, isn't valid PEM, is
+password-encrypted, or is the wrong key type, both raise `PrivateKeyError`
+(a `TeslaFleetError`) with a `reason` of `"unreadable"`, `"malformed"`,
+`"encrypted"`, or `"wrong_type"`.
 
 `VehicleBluetooth` keeps a held BLE connection alive during idle periods by
 default with a passive GATT read about every 20 seconds. Pass

--- a/README.md
+++ b/README.md
@@ -178,8 +178,9 @@ owner-writable only (`0600`) from the start, with no write-then-chmod window,
 and concurrent creators fall back to reading the file that won the create
 race. If an existing key file can't be read, isn't valid PEM, is
 password-encrypted, or is the wrong key type, both raise `PrivateKeyError`
-(a `TeslaFleetError`) with a `reason` of `"unreadable"`, `"malformed"`,
-`"encrypted"`, or `"wrong_type"`.
+(a `LibraryError`, not a `TeslaFleetError` - it's a local key-file failure,
+not an upstream Fleet API error) with a `reason` of `"unreadable"`,
+`"malformed"`, `"encrypted"`, or `"wrong_type"`.
 
 `VehicleBluetooth` keeps a held BLE connection alive during idle periods by
 default with a passive GATT read about every 20 seconds. Pass

--- a/docs/bluetooth_vehicles.md
+++ b/docs/bluetooth_vehicles.md
@@ -39,11 +39,9 @@ async def main():
 asyncio.run(main())
 ```
 
-`get_private_key(path)` loads an existing EC private key or creates a new
-unencrypted PEM key file. Newly created key files are created owner-readable
-and owner-writable only (`0600`) from the start, with no write-then-chmod
-window, and concurrent creators fall back to reading the file that won the
-create race.
+See the [README](../README.md#bluetooth-for-vehicles) for
+`get_private_key(path)`'s create/load semantics and the `PrivateKeyError`
+raised for an unusable existing key file.
 
 ## Keeping the Connection Alive (`keepalive_interval`)
 

--- a/docs/fleet_api_energy_sites.md
+++ b/docs/fleet_api_energy_sites.md
@@ -397,10 +397,9 @@ an empty or `null` response even when it is not useful for proving local key
 readiness.
 
 `get_rsa_private_key(path)` loads an existing RSA private key for gateway
-client registration or creates a new unencrypted PEM key file. Newly created
-key files are created owner-readable and owner-writable only (`0600`) from the
-start, with no write-then-chmod window, and concurrent creators fall back to
-reading the file that won the create race.
+client registration or creates a new unencrypted PEM key file; see the
+[README](../README.md#bluetooth-for-vehicles) for its create/load semantics
+and the `PrivateKeyError` raised for an unusable existing key file.
 
 ### Available Commands
 

--- a/tesla_fleet_api/exceptions.py
+++ b/tesla_fleet_api/exceptions.py
@@ -404,23 +404,6 @@ class DeviceUnexpectedResponse(TeslaFleetError):
     status = 540
 
 
-class PrivateKeyError(TeslaFleetError):
-    """An existing private key file could not be loaded as a usable key.
-
-    Raised by ``Tesla.get_private_key``/``get_rsa_private_key`` only for a
-    known-existing key file's read/parse failure - key generation and the
-    O_EXCL create-race fallback keep raising their original exceptions.
-    ``reason`` is one of ``"unreadable"`` (I/O failure), ``"malformed"`` (not
-    valid PEM), ``"encrypted"`` (PEM requires a passphrase), or
-    ``"wrong_type"`` (loaded key is not the expected type).
-    """
-
-    def __init__(self, reason: str, message: str) -> None:
-        self.reason = reason
-        self.message = message
-        super().__init__()
-
-
 class LibraryError(Exception):
     """Errors related to this library."""
 
@@ -440,6 +423,25 @@ class SigningDisabled(LibraryError):
             "broadcasts (the listen_* methods); any signed command or read "
             "needs a real private_key."
         )
+
+
+class PrivateKeyError(LibraryError):
+    """An existing private key file could not be loaded as a usable key.
+
+    Raised by ``Tesla.get_private_key``/``get_rsa_private_key`` only for a
+    known-existing key file's read/parse failure - key generation and the
+    O_EXCL create-race fallback keep raising their original exceptions.
+    ``reason`` is one of ``"unreadable"`` (I/O failure), ``"malformed"`` (not
+    valid PEM), ``"encrypted"`` (PEM requires a passphrase), or
+    ``"wrong_type"`` (loaded key is not the expected type). A local key-file
+    failure, not an upstream Fleet API error, so this subclasses
+    ``LibraryError`` rather than ``TeslaFleetError``.
+    """
+
+    def __init__(self, reason: str, message: str) -> None:
+        self.reason = reason
+        self.message = message
+        super().__init__(message)
 
 
 class SignedCommandRequired(TeslaFleetError):

--- a/tesla_fleet_api/exceptions.py
+++ b/tesla_fleet_api/exceptions.py
@@ -404,6 +404,23 @@ class DeviceUnexpectedResponse(TeslaFleetError):
     status = 540
 
 
+class PrivateKeyError(TeslaFleetError):
+    """An existing private key file could not be loaded as a usable key.
+
+    Raised by ``Tesla.get_private_key``/``get_rsa_private_key`` only for a
+    known-existing key file's read/parse failure - key generation and the
+    O_EXCL create-race fallback keep raising their original exceptions.
+    ``reason`` is one of ``"unreadable"`` (I/O failure), ``"malformed"`` (not
+    valid PEM), ``"encrypted"`` (PEM requires a passphrase), or
+    ``"wrong_type"`` (loaded key is not the expected type).
+    """
+
+    def __init__(self, reason: str, message: str) -> None:
+        self.reason = reason
+        self.message = message
+        super().__init__()
+
+
 class LibraryError(Exception):
     """Errors related to this library."""
 

--- a/tesla_fleet_api/tesla/tesla.py
+++ b/tesla_fleet_api/tesla/tesla.py
@@ -7,9 +7,11 @@ import os
 import sys
 import time
 from os.path import exists
+from typing import TypeVar
 import aiofiles
 
 from tesla_fleet_api.const import LOGGER
+from tesla_fleet_api.exceptions import PrivateKeyError
 from tesla_fleet_api.tesla.charging import Charging
 from tesla_fleet_api.tesla.energysite import EnergySites
 from tesla_fleet_api.tesla.partner import Partner
@@ -214,6 +216,46 @@ async def _load_pem_private_key(
             await asyncio.sleep(_KEY_READ_RETRY_INTERVAL)
 
 
+_KeyT = TypeVar("_KeyT", ec.EllipticCurvePrivateKey, rsa.RSAPrivateKey)
+
+
+async def _load_existing_private_key(
+    path: str,
+    expected_type: type[_KeyT],
+    unsafe_skip_rsa_key_validation: bool = False,
+) -> _KeyT:
+    """Read and parse a key file already known to exist, raising ``PrivateKeyError`` for every failure shape.
+
+    Only covers a known-existing file's read/parse - key generation and the
+    O_EXCL create-race fallback are separate call sites that keep raising
+    their original exceptions.
+    """
+    try:
+        value = await _load_pem_private_key(
+            path,
+            retry_invalid=True,
+            unsafe_skip_rsa_key_validation=unsafe_skip_rsa_key_validation,
+        )
+    except OSError as err:
+        raise PrivateKeyError(
+            "unreadable", f"Could not read private key file at {path}"
+        ) from err
+    except TypeError as err:
+        raise PrivateKeyError(
+            "encrypted", f"Private key file at {path} is encrypted"
+        ) from err
+    except ValueError as err:
+        raise PrivateKeyError(
+            "malformed", f"Private key file at {path} is not a valid PEM private key"
+        ) from err
+    if not isinstance(value, expected_type):
+        raise PrivateKeyError(
+            "wrong_type",
+            f"Private key file at {path} is not a {expected_type.__name__}",
+        )
+    return value
+
+
 class Tesla:
     """Base class describing interactions with Tesla products."""
 
@@ -258,15 +300,7 @@ class Tesla:
                 self.private_key = value
                 return self.private_key
 
-        try:
-            value = await _load_pem_private_key(path, retry_invalid=True)
-        except FileNotFoundError:
-            raise FileNotFoundError(f"Private key file not found at {path}")
-        except PermissionError:
-            raise PermissionError(f"Permission denied when trying to read {path}")
-
-        if not isinstance(value, ec.EllipticCurvePrivateKey):
-            raise AssertionError("Loaded key is not an EllipticCurvePrivateKey")
+        value = await _load_existing_private_key(path, ec.EllipticCurvePrivateKey)
         self.private_key = value
         return self.private_key
 
@@ -350,13 +384,9 @@ class Tesla:
                 self.rsa_private_key = value
                 return self.rsa_private_key
 
-        value = await _load_pem_private_key(
-            path,
-            retry_invalid=True,
-            unsafe_skip_rsa_key_validation=skip_rsa_key_validation,
+        value = await _load_existing_private_key(
+            path, rsa.RSAPrivateKey, skip_rsa_key_validation
         )
-        if not isinstance(value, rsa.RSAPrivateKey):
-            raise AssertionError("Loaded key is not an RSAPrivateKey")
         self.rsa_private_key = value
         return self.rsa_private_key
 

--- a/tests/test_tesla_private_key.py
+++ b/tests/test_tesla_private_key.py
@@ -19,6 +19,7 @@ from unittest import IsolatedAsyncioTestCase, mock
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
+from tesla_fleet_api.exceptions import PrivateKeyError
 from tesla_fleet_api.tesla.tesla import Tesla
 
 
@@ -715,3 +716,121 @@ class GetRsaPrivateKeyOptionalValidationTests(IsolatedAsyncioTestCase):
             read_back = await Tesla().get_rsa_private_key(path, key_size=1024)
 
             self.assertEqual(_rsa_pem(read_back), _rsa_pem(created))
+
+
+class PrivateKeyErrorTests(IsolatedAsyncioTestCase):
+    """An existing-but-unusable key file must raise ``PrivateKeyError`` with the right reason."""
+
+    async def test_ec_loader_unreadable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "private_key.pem")
+            os.mkdir(path)
+
+            with self.assertRaises(PrivateKeyError) as ctx:
+                await Tesla().get_private_key(path)
+
+            self.assertEqual(ctx.exception.reason, "unreadable")
+            self.assertIsInstance(ctx.exception.__cause__, OSError)
+            self.assertIn(path, ctx.exception.message)
+
+    async def test_ec_loader_malformed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "private_key.pem")
+            Path(path).write_bytes(b"not a pem file")
+
+            with self.assertRaises(PrivateKeyError) as ctx:
+                await Tesla().get_private_key(path)
+
+            self.assertEqual(ctx.exception.reason, "malformed")
+            self.assertIsInstance(ctx.exception.__cause__, ValueError)
+            self.assertIn(path, ctx.exception.message)
+
+    async def test_ec_loader_encrypted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "private_key.pem")
+            key = ec.generate_private_key(ec.SECP256R1())
+            pem = key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.BestAvailableEncryption(
+                    b"correct horse battery staple"
+                ),
+            )
+            Path(path).write_bytes(pem)
+
+            with self.assertRaises(PrivateKeyError) as ctx:
+                await Tesla().get_private_key(path)
+
+            self.assertEqual(ctx.exception.reason, "encrypted")
+            self.assertIsInstance(ctx.exception.__cause__, TypeError)
+            self.assertIn(path, ctx.exception.message)
+
+    async def test_ec_loader_wrong_type(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "private_key.pem")
+            key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
+            Path(path).write_bytes(_rsa_pem(key))
+
+            with self.assertRaises(PrivateKeyError) as ctx:
+                await Tesla().get_private_key(path)
+
+            self.assertEqual(ctx.exception.reason, "wrong_type")
+            self.assertIsNone(ctx.exception.__cause__)
+            self.assertIn(path, ctx.exception.message)
+
+    async def test_rsa_loader_unreadable(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            os.mkdir(path)
+
+            with self.assertRaises(PrivateKeyError) as ctx:
+                await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            self.assertEqual(ctx.exception.reason, "unreadable")
+            self.assertIsInstance(ctx.exception.__cause__, OSError)
+            self.assertIn(path, ctx.exception.message)
+
+    async def test_rsa_loader_malformed(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            Path(path).write_bytes(b"not a pem file")
+
+            with self.assertRaises(PrivateKeyError) as ctx:
+                await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            self.assertEqual(ctx.exception.reason, "malformed")
+            self.assertIsInstance(ctx.exception.__cause__, ValueError)
+            self.assertIn(path, ctx.exception.message)
+
+    async def test_rsa_loader_encrypted(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            key = rsa.generate_private_key(public_exponent=65537, key_size=1024)
+            pem = key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.TraditionalOpenSSL,
+                encryption_algorithm=serialization.BestAvailableEncryption(
+                    b"correct horse battery staple"
+                ),
+            )
+            Path(path).write_bytes(pem)
+
+            with self.assertRaises(PrivateKeyError) as ctx:
+                await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            self.assertEqual(ctx.exception.reason, "encrypted")
+            self.assertIsInstance(ctx.exception.__cause__, TypeError)
+            self.assertIn(path, ctx.exception.message)
+
+    async def test_rsa_loader_wrong_type(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            path = str(Path(tmp_dir) / "tedapi_rsa_private.pem")
+            key = ec.generate_private_key(ec.SECP256R1())
+            Path(path).write_bytes(_ec_pem(key))
+
+            with self.assertRaises(PrivateKeyError) as ctx:
+                await Tesla().get_rsa_private_key(path, key_size=1024)
+
+            self.assertEqual(ctx.exception.reason, "wrong_type")
+            self.assertIsNone(ctx.exception.__cause__)
+            self.assertIn(path, ctx.exception.message)


### PR DESCRIPTION
## Intent

Review-comment fix on PR 146: PrivateKeyError must subclass LibraryError, not TeslaFleetError, since a key-file failure is local to this library, not an upstream Fleet API error. Moved the class next to SigningDisabled under LibraryError in exceptions.py, kept the reason/message attributes and docstring, updated the docstring's rationale and the README line that described it as a TeslaFleetError subclass. LibraryError subclasses Exception (not BaseException); PrivateKeyError(...) from err raise sites in tesla.py are unaffected by this base-class change. Tests still assert PrivateKeyError itself and needed no changes.

## What Changed

- Added `PrivateKeyError` (a `LibraryError` subclass, not `TeslaFleetError`, since a key-file failure is local to this library rather than an upstream Fleet API error) with a `reason` of `"unreadable"`, `"malformed"`, `"encrypted"`, or `"wrong_type"`, plus a `message` attribute.
- `Tesla.get_private_key`/`get_rsa_private_key` now route a known-existing key file's read/parse failure through a shared `_load_existing_private_key` helper that raises `PrivateKeyError` for I/O errors, invalid PEM, password-encrypted PEM, and a loaded key of the wrong type, replacing the previous ad-hoc `FileNotFoundError`/`PermissionError`/`AssertionError` handling; key generation and the O_EXCL create-race fallback are unaffected.
- Updated the README and `docs/bluetooth_vehicles.md`/`docs/fleet_api_energy_sites.md` to document the new `PrivateKeyError` reasons and its `LibraryError` base, consolidating the create/load semantics description in the README with cross-references from the docs.
- Added `PrivateKeyErrorTests` covering unreadable, malformed, encrypted, and wrong-type key files for both the EC and RSA loaders.

## Risk Assessment

✅ Low: Small, well-scoped change: moves PrivateKeyError from TeslaFleetError to LibraryError, correctly threads the message through Exception.__init__ (required since LibraryError has no custom __init__ unlike TeslaFleetError), updates docs consistently, and has no internal call sites that catch TeslaFleetError/BaseException expecting to intercept PrivateKeyError, so no behavior regression.

## Testing

Ran the existing targeted unit tests in tests/test_tesla_private_key.py (all 38 pass unchanged, confirming the intent's claim that no test changes were needed) and additionally wrote a manual end-to-end script exercising the actual exception-hierarchy behavior change: it proves a caller's generic `except TeslaFleetError` handler no longer swallows PrivateKeyError post-fix, while `except LibraryError` does, and that `reason`/`message`/`str()` remain intact. No issues found; working tree left clean.

<details>
<summary>Evidence: End-to-end demonstration: PrivateKeyError escapes `except TeslaFleetError` but is caught by `except LibraryError`</summary>

```text
OK: propagated past except TeslaFleetError -> reason='malformed' message='Private key file at /tmp/.../key.pem is not a valid PEM private key'
OK: caught by except LibraryError -> reason='malformed'
OK: str(e)='Private key file at /tmp/.../key.pem is not a valid PEM private key'
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"bdb157249e8434d21cb175444eb48eca3538e951","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`uv run python -m pytest tests/test_tesla_private_key.py -v` (38 passed, including the 8 PrivateKeyErrorTests asserting reason/message/__cause__ unchanged)</code>
- <code>Manual script: constructed a malformed PEM file, called `Tesla().get_private_key(path)`, and confirmed `except TeslaFleetError` no longer catches the raised error while `except LibraryError` does, with `reason`, `message`, and `str(e)` all intact</code>
- <code>`issubclass(PrivateKeyError, LibraryError)` is True, `issubclass(PrivateKeyError, TeslaFleetError)` is False, `issubclass(LibraryError, Exception)` is True</code>
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
