### PR TITLE
fix(exceptions): classify 502 responses as TeslaFleetError

### DIFF
--- a/docs/energy_local_control.md
+++ b/docs/energy_local_control.md
@@ -200,6 +200,13 @@ a genuinely empty client list. Catch `InvalidResponse` (or
 will not catch it. Either way, a `null` response here tells you nothing
 about whether the key actually works.
 
+A 502 from any of the gateway-relay command endpoints
+(`add_authorized_client`, `authorized_clients`, `remove_authorized_client`,
+`networking_status`) means the Powerwall gateway itself is unreachable and
+raises `tesla_fleet_api.exceptions.EnergyGatewayUnreachable`, distinct from
+the generic `tesla_fleet_api.exceptions.BadGateway` a 502 from any other
+endpoint raises.
+
 To revoke a key, call `remove_authorized_client(public_key)` with its DER bytes
 or the base64 string returned by `list_authorized_clients()`. Removal does not
 require physical presence proof: any paired key can revoke every other key,

--- a/docs/energy_local_control.md
+++ b/docs/energy_local_control.md
@@ -200,12 +200,9 @@ a genuinely empty client list. Catch `InvalidResponse` (or
 will not catch it. Either way, a `null` response here tells you nothing
 about whether the key actually works.
 
-A 502 from any of the gateway-relay command endpoints
-(`add_authorized_client`, `authorized_clients`, `remove_authorized_client`,
-`networking_status`) means the Powerwall gateway itself is unreachable and
-raises `tesla_fleet_api.exceptions.EnergyGatewayUnreachable`, distinct from
-the generic `tesla_fleet_api.exceptions.BadGateway` a 502 from any other
-endpoint raises.
+Any 502 response, including one from a gateway-relay command endpoint, raises
+`tesla_fleet_api.exceptions.BadGateway` regardless of whether the response
+carries a JSON body.
 
 To revoke a key, call `remove_authorized_client(public_key)` with its DER bytes
 or the base64 string returned by `list_authorized_clients()`. Removal does not

--- a/tesla_fleet_api/exceptions.py
+++ b/tesla_fleet_api/exceptions.py
@@ -1,8 +1,14 @@
+import re
 from typing import Any
 
 import aiohttp
 
 from tesla_fleet_api.const import LOGGER
+
+_ENERGY_GATEWAY_RELAY_PATH_RE = re.compile(
+    r"/api/1/energy_sites/[^/]+/command/"
+    r"(add_authorized_client|authorized_clients|remove_authorized_client|networking_status)$"
+)
 
 
 class TeslaFleetError(BaseException):
@@ -379,6 +385,31 @@ class InternalServerError(TeslaFleetError):
 
     message = "An error occurred while processing the request."
     status = 500
+
+
+class BadGateway(TeslaFleetError):
+    """The server, acting as a gateway, received an invalid response from an upstream server."""
+
+    message = (
+        "The server, acting as a gateway, received an invalid response from an "
+        "upstream server."
+    )
+    status = 502
+
+
+class EnergyGatewayUnreachable(BadGateway):
+    """The Powerwall energy gateway could not be reached via the gateway relay.
+
+    Teslemetry's gateway relay answers with a 502 (with or without a JSON
+    body) when a customer's Powerwall gateway has dropped off the network -
+    a retryable condition, not an ordinary API failure. Raised only for the
+    gateway-relay endpoints the local-control pairing/authorized-clients flow
+    uses (``add_authorized_client``, ``authorized_clients``,
+    ``remove_authorized_client``, ``networking_status``); a 502 from any
+    other endpoint raises the generic ``BadGateway`` instead.
+    """
+
+    message = "The Powerwall energy gateway could not be reached via the gateway relay."
 
 
 class ServiceUnavailable(TeslaFleetError):
@@ -1368,6 +1399,10 @@ async def raise_for_status(resp: aiohttp.ClientResponse) -> None:
         raise ClientClosedRequest(data)
     elif resp.status == 500:
         raise InternalServerError(data)
+    elif resp.status == 502:
+        if _ENERGY_GATEWAY_RELAY_PATH_RE.search(resp.url.path):
+            raise EnergyGatewayUnreachable(data)
+        raise BadGateway(data)
     elif resp.status == 503:
         raise ServiceUnavailable(data)
     elif resp.status == 504:

--- a/tesla_fleet_api/exceptions.py
+++ b/tesla_fleet_api/exceptions.py
@@ -1,14 +1,8 @@
-import re
 from typing import Any
 
 import aiohttp
 
 from tesla_fleet_api.const import LOGGER
-
-_ENERGY_GATEWAY_RELAY_PATH_RE = re.compile(
-    r"/api/1/energy_sites/[^/]+/command/"
-    r"(add_authorized_client|authorized_clients|remove_authorized_client|networking_status)$"
-)
 
 
 class TeslaFleetError(BaseException):
@@ -395,21 +389,6 @@ class BadGateway(TeslaFleetError):
         "upstream server."
     )
     status = 502
-
-
-class EnergyGatewayUnreachable(BadGateway):
-    """The Powerwall energy gateway could not be reached via the gateway relay.
-
-    Teslemetry's gateway relay answers with a 502 (with or without a JSON
-    body) when a customer's Powerwall gateway has dropped off the network -
-    a retryable condition, not an ordinary API failure. Raised only for the
-    gateway-relay endpoints the local-control pairing/authorized-clients flow
-    uses (``add_authorized_client``, ``authorized_clients``,
-    ``remove_authorized_client``, ``networking_status``); a 502 from any
-    other endpoint raises the generic ``BadGateway`` instead.
-    """
-
-    message = "The Powerwall energy gateway could not be reached via the gateway relay."
 
 
 class ServiceUnavailable(TeslaFleetError):
@@ -1400,8 +1379,6 @@ async def raise_for_status(resp: aiohttp.ClientResponse) -> None:
     elif resp.status == 500:
         raise InternalServerError(data)
     elif resp.status == 502:
-        if _ENERGY_GATEWAY_RELAY_PATH_RE.search(resp.url.path):
-            raise EnergyGatewayUnreachable(data)
         raise BadGateway(data)
     elif resp.status == 503:
         raise ServiceUnavailable(data)

--- a/tests/test_bad_gateway_classification.py
+++ b/tests/test_bad_gateway_classification.py
@@ -1,0 +1,106 @@
+"""502 classification: gateway-relay endpoints vs. everything else.
+
+A 502 must always become a ``TeslaFleetError`` subclass, whether or not the
+response carries a JSON body - see ``tesla_fleet_api.exceptions.raise_for_status``.
+Only the Powerwall local-control gateway-relay endpoints get the specific
+``EnergyGatewayUnreachable``; every other 502 gets the generic ``BadGateway``.
+"""
+
+from contextlib import asynccontextmanager
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock, MagicMock
+
+from yarl import URL
+
+from tesla_fleet_api.const import Method
+from tesla_fleet_api.exceptions import BadGateway, EnergyGatewayUnreachable
+from tesla_fleet_api.tesla.fleet import TeslaFleetApi
+
+
+class _RequestTestApi(TeslaFleetApi):
+    """Expose the protected _request for testing."""
+
+    async def request(
+        self,
+        method: Method,
+        path: str,
+        params: dict[str, object] | None = None,
+        json: dict[str, object] | None = {},
+    ) -> dict[str, object]:
+        return await self._request(method, path, params=params, json=json)
+
+
+def _make_api(*, response: object) -> _RequestTestApi:
+    session = MagicMock()
+
+    @asynccontextmanager
+    async def _ctx(*args, **kwargs):
+        yield response
+
+    session.request = MagicMock(side_effect=lambda *a, **k: _ctx(*a, **k))
+    return _RequestTestApi(
+        session=session,
+        access_token="access-token",
+        server="https://fleet.example.com",
+    )
+
+
+def _fake_response(
+    *,
+    path: str,
+    content_type: str = "application/json",
+    json_body: object = None,
+    text_body: str = "",
+):
+    resp = MagicMock()
+    resp.status = 502
+    resp.ok = False
+    resp.content_type = content_type
+    resp.url = URL(f"https://fleet.example.com{path}")
+    resp.headers = {}
+    resp.json = AsyncMock(return_value=json_body if json_body is not None else {})
+    resp.text = AsyncMock(return_value=text_body)
+    return resp
+
+
+class BadGatewayClassificationTests(IsolatedAsyncioTestCase):
+    async def test_gateway_relay_502_with_json_body_raises_energy_gateway_unreachable(
+        self,
+    ) -> None:
+        resp = _fake_response(
+            path="/api/1/energy_sites/123/command/add_authorized_client",
+            json_body={"error": "gateway unreachable"},
+        )
+        api = _make_api(response=resp)
+        with self.assertRaises(EnergyGatewayUnreachable):
+            await api.request(
+                Method.POST, "api/1/energy_sites/123/command/add_authorized_client"
+            )
+
+    async def test_gateway_relay_bodyless_502_raises_energy_gateway_unreachable(
+        self,
+    ) -> None:
+        resp = _fake_response(
+            path="/api/1/energy_sites/123/command/authorized_clients",
+            content_type="text/plain",
+            text_body="",
+        )
+        api = _make_api(response=resp)
+        with self.assertRaises(EnergyGatewayUnreachable):
+            await api.request(
+                Method.GET, "api/1/energy_sites/123/command/authorized_clients"
+            )
+
+    async def test_non_gateway_endpoint_502_raises_generic_bad_gateway(self) -> None:
+        resp = _fake_response(
+            path="/api/1/vehicles/123/vehicle_data",
+            json_body={"error": "upstream error"},
+        )
+        api = _make_api(response=resp)
+        with self.assertRaises(BadGateway):
+            await api.request(Method.GET, "api/1/vehicles/123/vehicle_data")
+        # And it must not be misclassified as gateway-unreachable.
+        try:
+            await api.request(Method.GET, "api/1/vehicles/123/vehicle_data")
+        except BadGateway as e:
+            self.assertNotIsInstance(e, EnergyGatewayUnreachable)

--- a/tests/test_bad_gateway_classification.py
+++ b/tests/test_bad_gateway_classification.py
@@ -1,9 +1,8 @@
-"""502 classification: gateway-relay endpoints vs. everything else.
+"""502 classification: always a TeslaFleetError, regardless of body shape.
 
-A 502 must always become a ``TeslaFleetError`` subclass, whether or not the
-response carries a JSON body - see ``tesla_fleet_api.exceptions.raise_for_status``.
-Only the Powerwall local-control gateway-relay endpoints get the specific
-``EnergyGatewayUnreachable``; every other 502 gets the generic ``BadGateway``.
+A 502 must always become a ``TeslaFleetError`` subclass instead of leaking a
+raw ``aiohttp.ClientResponseError`` - see
+``tesla_fleet_api.exceptions.raise_for_status``.
 """
 
 from contextlib import asynccontextmanager
@@ -13,7 +12,7 @@ from unittest.mock import AsyncMock, MagicMock
 from yarl import URL
 
 from tesla_fleet_api.const import Method
-from tesla_fleet_api.exceptions import BadGateway, EnergyGatewayUnreachable
+from tesla_fleet_api.exceptions import BadGateway
 from tesla_fleet_api.tesla.fleet import TeslaFleetApi
 
 
@@ -64,34 +63,30 @@ def _fake_response(
 
 
 class BadGatewayClassificationTests(IsolatedAsyncioTestCase):
-    async def test_gateway_relay_502_with_json_body_raises_energy_gateway_unreachable(
-        self,
-    ) -> None:
+    async def test_json_bodied_502_raises_bad_gateway(self) -> None:
         resp = _fake_response(
             path="/api/1/energy_sites/123/command/add_authorized_client",
             json_body={"error": "gateway unreachable"},
         )
         api = _make_api(response=resp)
-        with self.assertRaises(EnergyGatewayUnreachable):
+        with self.assertRaises(BadGateway):
             await api.request(
                 Method.POST, "api/1/energy_sites/123/command/add_authorized_client"
             )
 
-    async def test_gateway_relay_bodyless_502_raises_energy_gateway_unreachable(
-        self,
-    ) -> None:
+    async def test_bodyless_502_raises_bad_gateway(self) -> None:
         resp = _fake_response(
             path="/api/1/energy_sites/123/command/authorized_clients",
             content_type="text/plain",
             text_body="",
         )
         api = _make_api(response=resp)
-        with self.assertRaises(EnergyGatewayUnreachable):
+        with self.assertRaises(BadGateway):
             await api.request(
                 Method.GET, "api/1/energy_sites/123/command/authorized_clients"
             )
 
-    async def test_non_gateway_endpoint_502_raises_generic_bad_gateway(self) -> None:
+    async def test_non_gateway_endpoint_502_also_raises_bad_gateway(self) -> None:
         resp = _fake_response(
             path="/api/1/vehicles/123/vehicle_data",
             json_body={"error": "upstream error"},
@@ -99,8 +94,3 @@ class BadGatewayClassificationTests(IsolatedAsyncioTestCase):
         api = _make_api(response=resp)
         with self.assertRaises(BadGateway):
             await api.request(Method.GET, "api/1/vehicles/123/vehicle_data")
-        # And it must not be misclassified as gateway-unreachable.
-        try:
-            await api.request(Method.GET, "api/1/vehicles/123/vehicle_data")
-        except BadGateway as e:
-            self.assertNotIsInstance(e, EnergyGatewayUnreachable)


### PR DESCRIPTION
## Intent

Move Powerwall gateway-unreachable classification out of Home Assistant into this library (HA core PR home-assistant/core#181320). Fix: any 502 response from the Fleet/Teslemetry API - bodied or bodyless - now raises tesla_fleet_api.exceptions.BadGateway(TeslaFleetError) instead of a JSON-bodied 502 leaking as a raw aiohttp.ClientResponseError (raise_for_status previously had no 502 branch at all). CAPTAIN REVIEW DECISION applied on this branch: an earlier version of this change also added a specialized EnergyGatewayUnreachable exception and per-endpoint (gateway-relay) 502 mapping scoped to the Powerwall local-control pairing/authorized-clients endpoints (add_authorized_client, authorized_clients, remove_authorized_client, networking_status). The captain reviewed PR #148 and decided a Powerwall gateway-relay 502 is not semantically distinct from any other 502, so that specialization was deliberately removed: EnergyGatewayUnreachable and the endpoint-matching regex are gone, and ALL 502s (from any endpoint) now raise the single generic BadGateway. Tests in tests/test_bad_gateway_classification.py were updated to match: a JSON-bodied 502 -> BadGateway (not ClientResponseError), a bodyless 502 -> BadGateway, and a 502 from a non-gateway endpoint -> BadGateway (same class, not a different one) - there is no longer any endpoint-specific branching to test. docs/energy_local_control.md was trimmed to one line stating any 502 raises BadGateway. No other status code mapping changed and there are no consumer-facing signature changes. This is a pragmatic-version PR: no version bump, since a separate release process cuts that.

## What Changed

- Added `BadGateway(TeslaFleetError)` (status 502) to `tesla_fleet_api/exceptions.py` and wired a `502` branch into `raise_for_status()`, so any 502 response — bodied or bodyless, from any endpoint — raises `BadGateway` instead of leaking an unhandled `aiohttp.ClientResponseError`.
- Added `tests/test_bad_gateway_classification.py` covering a JSON-bodied 502, a bodyless 502, and a 502 from a non-gateway endpoint, all asserting the same `BadGateway` class with no endpoint-specific branching.
- Updated `docs/energy_local_control.md` with a one-line note that any 502, including from a gateway-relay command endpoint, raises `BadGateway` regardless of body presence.

## Risk Assessment

✅ Low: Small, well-bounded change: adds a single BadGateway exception and one raise_for_status branch, cleanly reverts the previously-added endpoint-specific EnergyGatewayUnreachable/regex with no leftover references, matches the stated intent exactly, and is covered by behavioral tests that exercise the real request path.

## Testing

Ran the targeted regression suite tests/test_bad_gateway_classification.py (3/3 passed) covering JSON-bodied, bodyless, and non-gateway-endpoint 502 responses, all correctly raising the single generic BadGateway(TeslaFleetError); confirmed against the base commit that no 502 branch previously existed (500→503 directly), so a 502 would have leaked as a raw aiohttp.ClientResponseError, validating this is a genuine fix with real regression coverage. Also confirmed no residual EnergyGatewayUnreachable or endpoint-matching code remains anywhere in the repo, matching the captain's decision to keep the fix generic, and that docs/energy_local_control.md was trimmed as described. No code changes were needed; working tree is clean.

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<!-- no-mistakes-pipeline-attestation:v1 {"head_sha":"c43cffde0775066526ecf1fb40e3fac46d91c59f","steps":[{"step":"intent","status":"completed"},{"step":"rebase","status":"completed"},{"step":"review","status":"completed"},{"step":"test","status":"completed"},{"step":"document","status":"completed"},{"step":"lint","status":"completed"},{"step":"push","status":"completed"},{"step":"pr","status":"running"},{"step":"ci","status":"pending"}]} -->

<details>
<summary>✅ **intent** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Review** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- `uv run pytest tests/test_bad_gateway_classification.py -v (3 passed: test_json_bodied_502_raises_bad_gateway, test_bodyless_502_raises_bad_gateway, test_non_gateway_endpoint_502_also_raises_bad_gateway)`
- `git diff de474c00..c43cffd -- tesla_fleet_api/exceptions.py docs/energy_local_control.md (confirmed single generic BadGateway added, no per-endpoint branching)`
- `grep -rn EnergyGatewayUnreachable . (confirmed zero remaining references, matching captain's removal decision)`
- `git show de474c00:tesla_fleet_api/exceptions.py | grep 50[0-9] (confirmed base commit had no 502 branch, i.e. a 502 would have leaked as raw aiohttp.ClientResponseError before this fix)`
</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.
</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.
</details>
