### PR TITLE
fix(energy): don't let a None owned key clobber cloud in merge_local_into_cloud

### DIFF
--- a/tesla_fleet_api/router/energysite.py
+++ b/tesla_fleet_api/router/energysite.py
@@ -33,12 +33,17 @@ def merge_local_into_cloud(
     ownership test — a fixed owned-key set lets a caller overlay local
     readings without clobbering cloud values, and lets a local outage fall
     back to the cloud value instead of an unavailable one.
+
+    A key overlays only when it is owned, present in ``local``, and
+    ``local[key] is not None``; ``None`` means "not served this tick" and the
+    cloud value is kept, while any other falsy value (``0``, ``False``, ``""``)
+    still overlays.
     """
     merged = dict(cloud)
     if local is None:
         return merged
     for key in owned_keys:
-        if key in local:
+        if key in local and local[key] is not None:
             merged[key] = local[key]
     return merged
 

--- a/tests/test_energysite_merge_contract.py
+++ b/tests/test_energysite_merge_contract.py
@@ -40,6 +40,19 @@ class TestMergeLocalIntoCloud(unittest.TestCase):
         result = merge_local_into_cloud(cloud, local, LOCAL_LIVE_STATUS_KEYS)
         self.assertEqual(result["grid_power"], 0)
 
+    def test_falsy_bool_local_value_is_overlaid(self) -> None:
+        cloud = {"island_status": "on_grid"}
+        local = {"island_status": False}
+        result = merge_local_into_cloud(cloud, local, LOCAL_LIVE_STATUS_KEYS)
+        self.assertEqual(result["island_status"], False)
+
+    def test_owned_key_present_with_none_keeps_cloud_value(self) -> None:
+        cloud = {"solar_power": 100, "grid_power": 50}
+        local = {"solar_power": None, "grid_power": 75}
+        result = merge_local_into_cloud(cloud, local, LOCAL_LIVE_STATUS_KEYS)
+        self.assertEqual(result["solar_power"], 100)
+        self.assertEqual(result["grid_power"], 75)
+
     def test_local_keys_outside_owned_set_are_ignored(self) -> None:
         cloud = {"solar_power": 100}
         local = {"solar_power": 200, "some_unowned_field": "surprise"}


### PR DESCRIPTION
Fixes the presence-only overlay in `merge_local_into_cloud` (`tesla_fleet_api/router/energysite.py`): `PowerwallEnergySite.live_status()` returns all cloud keys with `None` for ones the gateway can't serve, so an owned key present with `None` was overwriting a good cloud value. Now overlays only when the key is owned, present, and not `None`; falsy-but-real values (`0`, `False`, `""`) still overlay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NJqvy4EqPJQwZbb2SGEHLh
